### PR TITLE
Use Strict Flag to Enforce Defensive Programming

### DIFF
--- a/backend/backend.js
+++ b/backend/backend.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var DOMModelObject;
 var regexOccurrenceMap = null;
 var index = null;
@@ -23,7 +25,6 @@ chrome.runtime.onConnect.addListener(function(port) {
             regexOccurrenceMap = null;
             index = null;
             regex = null;
-            this.close();
         });
     });
 });

--- a/content/content.js
+++ b/content/content.js
@@ -1,4 +1,6 @@
-chrome.runtime.onMessage.addListener(function(message, _, sendResponse) {
+"use strict";
+
+chrome.runtime.onMessage.addListener(function(message, sender, sendResponse) {
     if(message.action == 'init')
         sendResponse({model: buildDOMReferenceObject()});
     else if(message.action == 'update')

--- a/content/highlighter.js
+++ b/content/highlighter.js
@@ -152,8 +152,10 @@ function seekHighlight(index) {
 }
 
 function seekFocus(classSelector) {
+    var offset = $(classSelector).offset();
     $('html, body').animate({
-        scrollTop: $(classSelector).offset().top - 50 + 'px'
+        scrollTop: offset.top - 50 + 'px',
+        scrollLeft: offset.left - 50 + 'px'
     }, 'fast');
 }
 

--- a/content/highlighter.js
+++ b/content/highlighter.js
@@ -1,7 +1,9 @@
+"use strict";
+
 var yellowHighlightClass = "find-ext-highlight-yellow";
 var orangeHighlightClass = "find-ext-highlight-orange";
 
-chrome.runtime.onMessage.addListener(function(message, _, _) {
+chrome.runtime.onMessage.addListener(function(message, sender, response) {
     var index;
     if(message.action == 'highlight_update') {
         var occurrenceMap = message.occurrenceMap;
@@ -151,7 +153,7 @@ function seekHighlight(index) {
 
 function seekFocus(classSelector) {
     $('html, body').animate({
-        scrollTop: $(classSelector).offset().top - 25 + 'px'
+        scrollTop: $(classSelector).offset().top - 50 + 'px'
     }, 'fast');
 }
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "find+",
-  "version": "0.1.0",
+  "version": "1.1.0",
   "author": ["Michael Walz", "Brandon Richardson"],
   "manifest_version": 2,
   "description": "A find-in-page extension with regex functionality",

--- a/popup/extension.css
+++ b/popup/extension.css
@@ -1,6 +1,6 @@
 /* Popup Style */
 body {
-    margin: 3px 6px 3px 6px;
+    margin: 3px 3px 3px 3px;
 }
 
 div#popup-body {

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var port = chrome.runtime.connect({name: "popup_to_backend_port"});
 
 /**


### PR DESCRIPTION
Added the `Use Strict` flag in all JS files to enforce defensive programming. Also removed useless `this.close()` from background script, and improved scrolling.