### PR TITLE
Use Native Page Scrolling to Fix Scrolling Issues

### DIFF
--- a/content/highlighter.js
+++ b/content/highlighter.js
@@ -144,19 +144,11 @@ function highlightAll(occurrenceMap, regex) {
     }
 }
 
-//Seek darker highlight to specific occurrence index
 function seekHighlight(index) {
     var classSelector = '.' + generateOccurrenceIdentifier(index);
-    $(classSelector).addClass(orangeHighlightClass);
-    seekFocus(classSelector);
-}
-
-function seekFocus(classSelector) {
-    var offset = $(classSelector).offset();
-    $('html, body').animate({
-        scrollTop: offset.top - 50 + 'px',
-        scrollLeft: offset.left - 50 + 'px'
-    }, 'fast');
+    var $el = $(classSelector);
+    $el.addClass(orangeHighlightClass);
+    $el.get(0).scrollIntoView(true);
 }
 
 //Unwrap all elements that have the yellowHighlightClass/orangeHighlightClass class


### PR DESCRIPTION
Issue: #67 

Replaced our function for scrolling to an element with the native `scrollIntoView()` function. Although Chrome does not support options for smooth scrolling or setting an offset, it is the most reliable solution I have found thus far.

There is an issue logged for chrome to implement this behavior, so we may see this fixed in the next release of Chrome.

Chrome Issue [#648446](https://bugs.chromium.org/p/chromium/issues/detail?id=648446)