### PR TITLE
Search Text Only Visible on Page

### DIFF
--- a/content/content.js
+++ b/content/content.js
@@ -19,7 +19,7 @@ function buildDOMReferenceObject() {
     var DOMModelObject = {};
 
     var end = false, groupIndex = 0, blockLevels = [], elementBoundary = false;
-    var preformatted = {flag: false, index: null};
+    var preformatted = {flag: false, index: null}, hidden = {flag: false, index: null};
     var node;
     while(!end) {
         if(!node)
@@ -41,6 +41,20 @@ function buildDOMReferenceObject() {
             else if(preformatted.flag && nodeDepth <= preformatted.index) {
                 preformatted.flag = false;
                 preformatted.index = null;
+            }
+
+            if(!hidden.flag && isHiddenElement(node)) {
+                hidden.flag = true;
+                hidden.index = nodeDepth;
+            }
+            else if(hidden.flag && nodeDepth <= hidden.index) {
+                hidden.flag = false;
+                hidden.index = null;
+            }
+
+            if(hidden.flag) {
+                node = DOMTreeWalker.nextNode();
+                continue;
             }
 
             if(isElementNode(node)) {
@@ -145,6 +159,13 @@ function isPreformattedElement(node) {
         return;
 
     return node.tagName.toLowerCase() == 'pre' || node.style.whiteSpace.toLowerCase() == 'pre';
+}
+
+function isHiddenElement(node) {
+    if(!isElementNode(node))
+        return;
+
+    return node.style.display.toLowerCase() == 'none' || node.style.display.toLowerCase() == 'hidden';
 }
 
 //Remove All Highlighting and Injected Markup

--- a/content/content.js
+++ b/content/content.js
@@ -158,14 +158,27 @@ function isPreformattedElement(node) {
     if(!isElementNode(node))
         return;
 
-    return node.tagName.toLowerCase() == 'pre' || node.style.whiteSpace.toLowerCase() == 'pre';
+    if(node.tagName.toLowerCase() == 'pre')
+        return true;
+
+    var computedStyle = window.getComputedStyle(node);
+    if(computedStyle.getPropertyValue('whitespace').toLowerCase() == 'pre')
+        return true;
+
+    return false;
 }
 
 function isHiddenElement(node) {
     if(!isElementNode(node))
         return;
 
-    return node.style.display.toLowerCase() == 'none' || node.style.display.toLowerCase() == 'hidden';
+    var computedStyle = window.getComputedStyle(node);
+    if(computedStyle.getPropertyValue('display').toLowerCase() == 'none')
+        return true;
+    if(computedStyle.getPropertyValue('display').toLowerCase() == 'hidden')
+        return true;
+
+    return false;
 }
 
 //Remove All Highlighting and Injected Markup


### PR DESCRIPTION
Issue: https://github.com/brandon1024/find/issues/63

Previously, text that has the CSS property `display: none` or `display: hidden` were included in the DOM model object and were parsed by the regex search engine. This caused an issue because it would display occurrences of a regex that are not visible to the user.

These changes address that. Added a flag to the content script for building the model object that skips all elements (and children of elements) that have the display property none or hidden. Also modified preformatted flag to use a more rigorous check for css properties.

### Tested:
#### In Develop:
1. Testing Element Style: Loaded a web page, used the developer tools to find a container with some text and added the element style for `display: none`. Ran the extension, searching for text in the hidden container, occurrence is found (even though the text is not visible on the page). 👎 
2. Testing Style with CSS: Created a mock web page with stylesheets, where one element on the page has a css property for `display: none`. Ran the extension, searching for text in the hidden container, occurrence is found (even though the text is not visible on the page). 👎 

#### In this branch:
1. Testing Element Style: Loaded a web page, used the developer tools to find a container with some text and added the element style for `display: none`. Ran the extension, searching for text in the hidden container, occurrence is not found. 👍 
2. Testing Style with CSS: Created a mock web page with stylesheets, where one element on the page has a css property for `display: none`. Ran the extension, searching for text in the hidden container, occurrence is not found. 👍 