### PR TITLE
HTML Entity Decoding

### DIFF
--- a/backend/backend.js
+++ b/backend/backend.js
@@ -106,7 +106,6 @@ function actionPrevious(port, tabID) {
 
 //Build occurrence map from DOM model and regex
 function buildOccurrenceMap(DOMModelObject, regex) {
-    regex = new RegExp(regex, 'gm');
     var occurrenceMap = {occurrenceIndexMap: {}, length: null, groups: null};
     var count = 0, groupIndex = 0;
 
@@ -118,8 +117,8 @@ function buildOccurrenceMap(DOMModelObject, regex) {
             uuids.push(textNodes[nodeIndex].elementUUID);
         }
 
-        textGroup = decode(textGroup);
-
+        regex = regex.replace(/ /g, '\s');
+        regex = new RegExp(regex, 'gm');
         var matches = textGroup.match(regex);
         if(!matches)
             continue;
@@ -138,42 +137,6 @@ function buildOccurrenceMap(DOMModelObject, regex) {
     occurrenceMap.length = count;
     occurrenceMap.groups = groupIndex;
     return occurrenceMap;
-}
-
-//Replace ASCII HTML character entities with their actual character representation
-function decode(string) {
-    var regex = /&(#[xX])?.*?;/g;
-
-    string = string.replace(regex, function(regexMatch) {
-        var entities = {9: ['tab'], 10: ['newline'], 32: ['nbsp', 'nonbreakingspace'], 33: ['excl'], 34: ['quot'], 35: ['num'], 36: ['dollar'], 37: ['percnt'], 38: ['amp'], 39: ['apos'], 40: ['lpar'], 41: ['rpar'], 42: ['ast', 'midast'], 43: ['plus'], 44: ['comma'], 45: ['period'], 46: ['sol'], 47: [], 48: [], 49: [], 50: [], 51: [], 52: [], 53: [], 54: [], 55: [], 56: [], 57: [], 58: ['colon'], 59: ['semi'], 60: ['lt'], 61: ['equals'], 62: ['gt'], 63: ['quest'], 64: ['commat'], 65: [], 66: [], 67: [], 68: [], 69: [], 70: [], 71: [], 72: [], 73: [], 74: [], 75: [], 76: [], 77: [], 78: [], 79: [], 80: [], 81: [], 82: [], 83: [], 84: [], 85: [], 86: [], 87: [], 88: [], 89: [], 90: [], 91: ['lsqb', 'lbrack'], 92: ['bsol'], 93: ['rsqb', 'rbrack'], 94: ['hat'], 95: ['lowbar'], 96: ['grave', 'diacritialgrave'], 97: [], 98: [], 99: [], 100: [], 101: [], 102: [], 103: [], 104: [], 105: [], 106: [], 107: [], 108: [], 109: [], 110: [], 111: [], 112: [], 113: [], 114: [], 115: [], 116: [], 117: [], 118: [], 119: [], 120: [], 121: [], 122: [], 123: ['lcub', 'lbrace'], 124: ['verbar', 'vert', 'verticalline'], 125: ['rcub', 'rbrace'], 126: ['tilde', 'diacriticaltilde']};
-        var strippedMatch = regexMatch.replace(/[&;]/g, '');
-
-        if(strippedMatch.charAt(0) == '#') {
-            strippedMatch = strippedMatch.replace(/#/, '');
-
-            var charCode;
-            if(strippedMatch.charAt(0).toLowerCase() == 'x')
-                charCode = parseInt('0' + strippedMatch);
-            else
-                charCode = parseInt(strippedMatch);
-
-            if(entities[charCode])
-                return String.fromCharCode(charCode);
-        }
-        else {
-            strippedMatch = strippedMatch.toLowerCase();
-            for(var key in entities) {
-                for(var index = 0; index < entities[key].length; index++) {
-                    if(entities[key][index] == strippedMatch)
-                        return String.fromCharCode(key);
-                }
-            }
-        }
-
-        return regexMatch;
-    });
-
-    return string;
 }
 
 //Get all group uuids from model object

--- a/backend/backend.js
+++ b/backend/backend.js
@@ -108,6 +108,8 @@ function actionPrevious(port, tabID) {
 function buildOccurrenceMap(DOMModelObject, regex) {
     var occurrenceMap = {occurrenceIndexMap: {}, length: null, groups: null};
     var count = 0, groupIndex = 0;
+    regex = regex.replace(/ /g, '\\s');
+    regex = new RegExp(regex, 'gm');
 
     for(var key in DOMModelObject) {
         var textNodes = DOMModelObject[key].group, preformatted = DOMModelObject[key].preformatted;
@@ -117,8 +119,6 @@ function buildOccurrenceMap(DOMModelObject, regex) {
             uuids.push(textNodes[nodeIndex].elementUUID);
         }
 
-        regex = regex.replace(/ /g, '\s');
-        regex = new RegExp(regex, 'gm');
         var matches = textGroup.match(regex);
         if(!matches)
             continue;

--- a/backend/backend.js
+++ b/backend/backend.js
@@ -118,6 +118,8 @@ function buildOccurrenceMap(DOMModelObject, regex) {
             uuids.push(textNodes[nodeIndex].elementUUID);
         }
 
+        textGroup = decode(textGroup);
+
         var matches = textGroup.match(regex);
         if(!matches)
             continue;
@@ -136,6 +138,42 @@ function buildOccurrenceMap(DOMModelObject, regex) {
     occurrenceMap.length = count;
     occurrenceMap.groups = groupIndex;
     return occurrenceMap;
+}
+
+//Replace ASCII HTML character entities with their actual character representation
+function decode(string) {
+    var regex = /&(#[xX])?.*?;/g;
+
+    string = string.replace(regex, function(regexMatch) {
+        var entities = {9: ['tab'], 10: ['newline'], 32: ['nbsp', 'nonbreakingspace'], 33: ['excl'], 34: ['quot'], 35: ['num'], 36: ['dollar'], 37: ['percnt'], 38: ['amp'], 39: ['apos'], 40: ['lpar'], 41: ['rpar'], 42: ['ast', 'midast'], 43: ['plus'], 44: ['comma'], 45: ['period'], 46: ['sol'], 47: [], 48: [], 49: [], 50: [], 51: [], 52: [], 53: [], 54: [], 55: [], 56: [], 57: [], 58: ['colon'], 59: ['semi'], 60: ['lt'], 61: ['equals'], 62: ['gt'], 63: ['quest'], 64: ['commat'], 65: [], 66: [], 67: [], 68: [], 69: [], 70: [], 71: [], 72: [], 73: [], 74: [], 75: [], 76: [], 77: [], 78: [], 79: [], 80: [], 81: [], 82: [], 83: [], 84: [], 85: [], 86: [], 87: [], 88: [], 89: [], 90: [], 91: ['lsqb', 'lbrack'], 92: ['bsol'], 93: ['rsqb', 'rbrack'], 94: ['hat'], 95: ['lowbar'], 96: ['grave', 'diacritialgrave'], 97: [], 98: [], 99: [], 100: [], 101: [], 102: [], 103: [], 104: [], 105: [], 106: [], 107: [], 108: [], 109: [], 110: [], 111: [], 112: [], 113: [], 114: [], 115: [], 116: [], 117: [], 118: [], 119: [], 120: [], 121: [], 122: [], 123: ['lcub', 'lbrace'], 124: ['verbar', 'vert', 'verticalline'], 125: ['rcub', 'rbrace'], 126: ['tilde', 'diacriticaltilde']};
+        var strippedMatch = regexMatch.replace(/[&;]/g, '');
+
+        if(strippedMatch.charAt(0) == '#') {
+            strippedMatch = strippedMatch.replace(/#/, '');
+
+            var charCode;
+            if(strippedMatch.charAt(0).toLowerCase() == 'x')
+                charCode = parseInt('0' + strippedMatch);
+            else
+                charCode = parseInt(strippedMatch);
+
+            if(entities[charCode])
+                return String.fromCharCode(charCode);
+        }
+        else {
+            strippedMatch = strippedMatch.toLowerCase();
+            for(var key in entities) {
+                for(var index = 0; index < entities[key].length; index++) {
+                    if(entities[key][index] == strippedMatch)
+                        return String.fromCharCode(key);
+                }
+            }
+        }
+
+        return regexMatch;
+    });
+
+    return string;
 }
 
 //Get all group uuids from model object

--- a/content/content.js
+++ b/content/content.js
@@ -128,7 +128,7 @@ function formatTextNodeValue(node, preformatted, elementBoundary) {
     if(isElementNode(node))
         return;
 
-    var nodeText = node.nodeValue;
+    var nodeText = decode(node.nodeValue);
     if(preformatted)
         return nodeText;
 

--- a/content/highlighter.js
+++ b/content/highlighter.js
@@ -31,9 +31,10 @@ chrome.runtime.onMessage.addListener(function(message, sender, response) {
 //Highlight all occurrences on the page
 function highlightAll(occurrenceMap, regex) {
     var occIndex = 0;
+    regex = regex.replace(/ /g, '\\s');
+    regex = new RegExp(regex, 'gm');
+
     for(var index = 0; index < occurrenceMap.groups; index++) {
-        regex = regex.replace(/ /g, '\s');
-        regex = new RegExp(regex, 'gm');
         var uuids = occurrenceMap[index].uuids;
         var groupText = '', charMap = {}, charIndexMap = [];
 
@@ -121,7 +122,7 @@ function highlightAll(occurrenceMap, regex) {
                 matchGroup.groupUUID = charMap[key].nodeUUID;
 
             if(matchGroup.groupUUID != charMap[key].nodeUUID) {
-                document.getElementById(matchGroup.groupUUID).innerHTML = encode(matchGroup.text);
+                document.getElementById(matchGroup.groupUUID).innerHTML = matchGroup.text;
                 matchGroup.text = '';
                 matchGroup.groupUUID = charMap[key].nodeUUID;
             }
@@ -140,9 +141,9 @@ function highlightAll(occurrenceMap, regex) {
                 }
             }
 
-            matchGroup.text += charMap[key].char;
+            matchGroup.text += encode(charMap[key].char);
         }
-        document.getElementById(matchGroup.groupUUID).innerHTML = encode(matchGroup.text);
+        document.getElementById(matchGroup.groupUUID).innerHTML = matchGroup.text;
     }
 }
 

--- a/content/highlighter.js
+++ b/content/highlighter.js
@@ -32,7 +32,8 @@ chrome.runtime.onMessage.addListener(function(message, sender, response) {
 function highlightAll(occurrenceMap, regex) {
     var occIndex = 0;
     for(var index = 0; index < occurrenceMap.groups; index++) {
-        regex = new RegExp(regex);
+        regex = regex.replace(/ /g, '\s');
+        regex = new RegExp(regex, 'gm');
         var uuids = occurrenceMap[index].uuids;
         var groupText = '', charMap = {}, charIndexMap = [];
 
@@ -44,6 +45,7 @@ function highlightAll(occurrenceMap, regex) {
             if(!text)
                 continue;
 
+            text = decode(text);
             groupText += text;
 
             for(var stringIndex = 0; stringIndex < text.length; stringIndex++) {
@@ -119,7 +121,7 @@ function highlightAll(occurrenceMap, regex) {
                 matchGroup.groupUUID = charMap[key].nodeUUID;
 
             if(matchGroup.groupUUID != charMap[key].nodeUUID) {
-                document.getElementById(matchGroup.groupUUID).innerHTML = matchGroup.text;
+                document.getElementById(matchGroup.groupUUID).innerHTML = encode(matchGroup.text);
                 matchGroup.text = '';
                 matchGroup.groupUUID = charMap[key].nodeUUID;
             }
@@ -140,7 +142,7 @@ function highlightAll(occurrenceMap, regex) {
 
             matchGroup.text += charMap[key].char;
         }
-        document.getElementById(matchGroup.groupUUID).innerHTML = matchGroup.text;
+        document.getElementById(matchGroup.groupUUID).innerHTML = encode(matchGroup.text);
     }
 }
 

--- a/content/highlighter.js
+++ b/content/highlighter.js
@@ -125,6 +125,9 @@ function highlightAll(occurrenceMap, regex) {
                 document.getElementById(matchGroup.groupUUID).innerHTML = matchGroup.text;
                 matchGroup.text = '';
                 matchGroup.groupUUID = charMap[key].nodeUUID;
+
+                if(inMatch)
+                    matchGroup.text += openingMarkup;
             }
 
             if(charMap[key].matched) {

--- a/lib/html-entity-handler/entityhandler.js
+++ b/lib/html-entity-handler/entityhandler.js
@@ -1,0 +1,53 @@
+var encodedEntities = {
+    9:['tab'],10:['newline'],32:[],33:['excl'],34:['quot'],35:['num'],36:['dollar'], 37:['percnt'],38:['amp'],39:['apos'],
+    40:['lpar'],41:['rpar'],42:['ast','midast'],43:['plus'],44:['comma'],45:['period'],46:['sol'],47:[],48:[],49:[],50:[],
+    51:[],52:[],53:[],54:[],55:[],56:[],57:[],58:['colon'],59:['semi'],60:['lt'],61:['equals'],62:['gt'],63:['quest'],
+    64:['commat'],65:[],66:[],67:[],68:[],69:[],70:[],71:[],72:[],73:[],74:[],75:[],76:[],77:[],78:[],79:[],80:[],81:[],
+    82:[],83:[],84:[],85:[],86:[],87:[],88:[],89:[],90:[],91:['lsqb','lbrack'],92:['bsol'],93:['rsqb','rbrack'],94:['hat'],
+    95:['lowbar'],96:['grave','diacritialgrave'],97:[],98:[],99:[],100:[],101:[],102:[],103:[],104:[],105:[],106:[],107:[],
+    108:[],109:[],110:[],111:[],112:[],113:[],114:[],115:[],116:[],117:[],118:[],119:[],120:[],121:[],122:[],123:['lcub','lbrace'],
+    124:['verbar','vert','verticalline'],125:['rcub','rbrace'],126:['tilde','diacriticaltilde'],160:['nbsp','nonbreakingspace']
+};
+
+var decodedEntities = {
+    9:['tab'],10:['newline'],34:['quot'],38:['amp'],39:['apos'],60:['lt'],62:['gt'],160:['nbsp','nonbreakingspace']
+};
+
+//Replace ASCII HTML character entities with their actual character representation
+function decode(string) {
+    var regex = /&(#[xX]?)?.*?;/g;
+
+    string = string.replace(regex, function(regexMatch) {
+        var strippedMatch = regexMatch.replace(/[&;]/g, '');
+
+        if(strippedMatch.charAt(0) == '#') {
+            strippedMatch = strippedMatch.replace(/#/, '');
+
+            var charCode;
+            if(strippedMatch.charAt(0).toLowerCase() == 'x')
+                charCode = parseInt('0' + strippedMatch);
+            else
+                charCode = parseInt(strippedMatch);
+
+            if(encodedEntities[charCode])
+                return String.fromCharCode(charCode);
+        }
+        else {
+            strippedMatch = strippedMatch.toLowerCase();
+            for(var key in encodedEntities) {
+                for(var index = 0; index < encodedEntities[key].length; index++) {
+                    if(encodedEntities[key][index] == strippedMatch)
+                        return String.fromCharCode(key);
+                }
+            }
+        }
+
+        return regexMatch;
+    });
+
+    return string;
+}
+
+function encode(string) {
+
+}

--- a/lib/html-entity-handler/entityhandler.js
+++ b/lib/html-entity-handler/entityhandler.js
@@ -48,6 +48,16 @@ function decode(string) {
     return string;
 }
 
+//Encode characters described above into HTML safe text
 function encode(string) {
+    for(var index = 0; index < string.length; index++) {
+        var charCode = string.charCodeAt(index);
+        if(!decodedEntities[charCode])
+            continue;
 
+        var encodedEntity = '&' + decodedEntities[charCode][0] + ';';
+        string = string.substring(0, index) + encodedEntity + string.substring(index + 1);
+    }
+
+    return string;
 }

--- a/manifest.json
+++ b/manifest.json
@@ -30,7 +30,10 @@
       "matches": ["<all_urls>"],
       "all_frames": false,
       "run_at": "document_end",
-      "js": ["/lib/jQuery/jquery-3.2.0.min.js", "/content/content.js", "/content/highlighter.js"],
+      "js": ["/lib/jQuery/jquery-3.2.0.min.js",
+        "/lib/html-entity-handler/entityhandler.js",
+        "/content/content.js",
+        "/content/highlighter.js"],
       "css": ["/content/highlighter.css"]
     }
   ],


### PR DESCRIPTION
Issue: #64 

Implemented a HTML entity encoder/decoder content script that is injected into the webpage along with the content.js and highlighter.js. It is used to convert typical (and nontypical) HTML character entities to their ASCII character. 

Originally, characters that appear as their entity in text nodes would throw off the regex search, causing the entity to be interpreted as the entity code characters. 

The decoder is designed translates html character entities for codes `9, 10, 32-126, 160`. This represents all printable ASCII characters, and the non breaking space character.

The encoder only encodes characters the following characters used in HTML markup and formatting: `tab, newline, single quote, double quote, ampersand, <, >, non breaking space`.

This PR also addresses an issue in the highlighter. Our highlighter markup was being inserted at the beginning and end of matched characters, but not closed and opened properly when the matched characters exist in more than one node.