### PR TITLE
Webpage Restoration Fix

### DIFF
--- a/content/content.js
+++ b/content/content.js
@@ -183,10 +183,24 @@ function isHiddenElement(node) {
 
 //Remove All Highlighting and Injected Markup
 function restoreWebPage(uuids) {
-    for(var index = 0; index < uuids.length; index++) {
-        var elementUUID = '#' + uuids[index];
-        $(elementUUID).contents().unwrap();
+    function unwrapContentFromID(id) {
+        var idSelector = '#' + id;
+        var $el = $(idSelector);
+
+        if($el.length == 0)
+            return;
+
+        var $parent = $el.parent();
+        $el.replaceWith(function() {
+            return $(this).contents();
+        });
+
+        for(var index = 0; index < $parent.length; index++)
+            $parent[index].normalize();
     }
+
+    for(var index = 0; index < uuids.length; index++)
+        unwrapContentFromID(uuids[index]);
 
     return true;
 }

--- a/content/highlighter.js
+++ b/content/highlighter.js
@@ -167,7 +167,9 @@ function restore() {
             return;
 
         var $parent = $el.parent();
-        $(classSelector).contents().unwrap();
+        $el.replaceWith(function() {
+            return $(this).contents();
+        });
 
         for(var index = 0; index < $parent.length; index++)
             $parent[index].normalize();
@@ -176,7 +178,6 @@ function restore() {
     for(var argIndex = 0; argIndex < arguments.length; argIndex++)
         unwrapContentFromClass(arguments[argIndex]);
 }
-
 
 //Remove class from all element with that class
 function restoreClass() {


### PR DESCRIPTION
Issue: #71 

When the `contents()` function is invoked on a jQuery object, it returns all children nodes to that object. However, when no children nodes exist, an empty object is returned. Invoking `unwrap()` on the contents will have no effect. This caused issues with highlighting, but more importantly left unwanted markup in the webpage after the extension is closed.

To fix this issue, I used the 'replaceWith()' function. If the contents of the jquery object is empty, the element will simply be removed from the DOM.

```
   $el.replaceWith(function() {
        return $(this).contents();
     });
```