### PR TITLE
jQuery Performance Improvements

### DIFF
--- a/backend/backend.js
+++ b/backend/backend.js
@@ -27,6 +27,15 @@ chrome.runtime.onConnect.addListener(function(port) {
             regex = null;
         });
     });
+
+    chrome.tabs.query({active: true, currentWindow: true}, function (tabs) {
+        chrome.tabs.sendMessage(tabs[0].id, {action: 'init'}, function (response) {
+            if(response && response.model) {
+                DOMModelObject = response.model;
+                index = 0;
+            }
+        });
+    });
 });
 
 //Dispatch action function
@@ -41,14 +50,8 @@ function invokeAction(action, port, tabID, message) {
 
 //Action Update
 function actionUpdate(port, tabID, message) {
-    var action = (!DOMModelObject ? 'init' : 'update');
-    chrome.tabs.sendMessage(tabID, {action: action}, function (response) {
+    chrome.tabs.sendMessage(tabID, {action: 'update'}, function (response) {
         try {
-            if(response && response.model) {
-                DOMModelObject = response.model;
-                index = 0;
-            }
-
             if(!DOMModelObject)
                 return;
 

--- a/content/content.js
+++ b/content/content.js
@@ -98,9 +98,10 @@ function buildDOMReferenceObject() {
                     continue;
                 }
 
-                var $wrapperElement = $(document.createElement('span'));
-                $wrapperElement.attr('id', identifierUUID);
-                $(node).wrap($wrapperElement);
+                var $wrapperElement = document.createElement('span');
+                $wrapperElement.setAttribute('id', identifierUUID);
+                node.parentNode.insertBefore($wrapperElement, node);
+                $wrapperElement.appendChild(node);
 
                 var textNodeInformation = {groupIndex: groupIndex, text: nodeText, elementUUID: identifierUUID};
                 textGroup.group.push(textNodeInformation);


### PR DESCRIPTION
Issue: #77 

As mentioned in #77, using JavaScript performance profiling functions, I recorded that in a GitHub diff, our extension took on average 375ms to build the DOM model object. Digging deeper, I found that a large majority of this time is due to the fact that jQuery is used to wrap text nodes with our markup.

By replacing jQuery with vanilla JavaScript, `I was able to reduce 375ms down to around 189ms. This is a performance improvement of nearly 50%`.

Also as part of this PR, I moved the init action code in the background script to instead build the DOM model object when the extension first loads, i.e. when the background script receives an onConnect event. This improves the user-apparent performance/initial responsiveness. 