### PR TITLE
Scrolling to Text In Footer Fix

### DIFF
--- a/content/highlighter.js
+++ b/content/highlighter.js
@@ -171,8 +171,12 @@ function seekHighlight(index) {
     var classSelector = '.find-ext-occr' + index;
     var $el = $(classSelector);
     $el.addClass(orangeHighlightClass);
+
     $el.get(0).scrollIntoView(true);
-    window.scrollBy(0,-100);
+    var docHeight = Math.max(document.documentElement.clientHeight, document.documentElement.offsetHeight, document.documentElement.scrollHeight);
+    var bottomScrollPos = window.pageYOffset + window.innerHeight;
+    if(bottomScrollPos + 100 < docHeight)
+        window.scrollBy(0,-100);
 }
 
 //Unwrap all elements that have the yellowHighlightClass/orangeHighlightClass class


### PR DESCRIPTION
Issue: #79

Currently, in `seekHighlight`, `window.scrollBy(0,-100);` is executed regardless of where the text is in the page. However, if a highlight appears in the bottom of the page, this should not be executed.

In this PR, I addressed this issue by conditionally executing the upwards scroll based on the position of the scrollbar after the `scrollIntoView()`.