### PR TITLE
Chrome Web Store 'Runs Offline' Flag

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -44,5 +44,6 @@
         "mac": "Ctrl+Shift+F"
       }
     }
-  }
+  },
+  "offline_enabled": true
 }


### PR DESCRIPTION
Added the `offline_enable` flag to the manifest, which will allow the extension to be found when the Runs offline flag is set on the web store.

Testing can only be done when published.