### PR TITLE
Regex Error Icon/Notification

### DIFF
--- a/popup/extension.css
+++ b/popup/extension.css
@@ -125,3 +125,10 @@ img#exclamation-icon {
     height: 20px;
     padding: 10px;
 }
+
+img#invalid-regex-icon {
+    width: 10px;
+    height: 10px;
+    float: right;
+    display: none;
+}

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -17,6 +17,7 @@
                 </td>
                 <td id="index-text-cell">
                     <span id="index-text"></span>
+                    <img id="invalid-regex-icon" src="/resources/exclamation.svg" title="Malformed Regex:&#013;The regular expression entered is not acceptable, as it is either:&#013;&#09;- an invalid regular expression, or&#013;&#09;- not supported according to the Javascript RegExp specification"/>
                 </td>
                 <td id="divide-line-cell">
                     <img id="dividing-line-img" src="/resources/line.png"/>

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -42,6 +42,7 @@ window.onload = function addListeners() {
 //Listen for messages from the background script
 port.onMessage.addListener(function listener(response) {
     if(response.action == 'index_update') {
+        showMalformedRegexIcon(false);
         updateIndexText(response.index, response.total);
 
         if(response.index == 0 && response.total == 0)
@@ -56,6 +57,7 @@ port.onMessage.addListener(function listener(response) {
     else if(response.action == 'invalid_regex') {
         updateIndexText();
         disableButtons();
+        showMalformedRegexIcon(true);
     }
     else {
         console.error('Unrecognized action:', response.action);
@@ -150,6 +152,14 @@ function updateIndexText() {
         document.getElementById('index-text').innerText = '';
     else if(arguments.length == 2)
         document.getElementById('index-text').innerText = formatNumber(arguments[0]) + ' of ' + formatNumber(arguments[1]);
+}
+
+//Show or hide red exclamation icon in the extension popup
+function showMalformedRegexIcon(flag) {
+    if(flag)
+        document.getElementById('invalid-regex-icon').style.display = 'initial';
+    else
+        document.getElementById('invalid-regex-icon').style.display = 'none';
 }
 
 //Enable next and previous buttons

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -41,8 +41,8 @@ window.onload = function addListeners() {
 
 //Listen for messages from the background script
 port.onMessage.addListener(function listener(response) {
-    showMalformedRegexIcon(false);
     if(response.action == 'index_update') {
+        showMalformedRegexIcon(false);
         updateIndexText(response.index, response.total);
 
         if(response.index == 0 && response.total == 0)
@@ -51,6 +51,7 @@ port.onMessage.addListener(function listener(response) {
             enableButtons();
     }
     else if(response.action == 'empty_regex') {
+        showMalformedRegexIcon(false);
         updateIndexText();
         disableButtons();
     }

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -13,13 +13,9 @@ window.onload = function addListeners() {
 
     chrome.tabs.query({'active': true, currentWindow: true}, function (tabs) {
         var url = tabs[0].url;
-        if(url.match(/chrome:\/\/.*/)) {
+        if(url.match(/chrome:\/\/.*/) || url.match(/https:\/\/chrome.google.com\/webstore\/.*/)) {
             document.getElementById('extension-message-body').style.display = 'initial';
             document.getElementById('extension-limitation-chrome-settings-text').style.display = 'initial';
-        }
-        else if(url.match(/https:\/\/chrome.google.com\/webstore\/.*/)) {
-            document.getElementById('extension-message-body').style.display = 'initial';
-            document.getElementById('extension-limitation-web-store-text').style.display = 'initial';
         }
         else
         {

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -41,8 +41,8 @@ window.onload = function addListeners() {
 
 //Listen for messages from the background script
 port.onMessage.addListener(function listener(response) {
+    showMalformedRegexIcon(false);
     if(response.action == 'index_update') {
-        showMalformedRegexIcon(false);
         updateIndexText(response.index, response.total);
 
         if(response.index == 0 && response.total == 0)


### PR DESCRIPTION
Added a small exclamation icon in place of the index text when a malformed regex is entered. Hovering over the icon will display a small tooltip with information to the user.

#### Icon:
![image](https://user-images.githubusercontent.com/22732449/30175750-40e09960-93d6-11e7-882b-25a475af2567.png)

#### Tooltip:
![image](https://user-images.githubusercontent.com/22732449/30175774-5a741ee2-93d6-11e7-9211-07e769e86982.png)