### PR TITLE
Usability Inconsistency with Native Tool

### DIFF
--- a/popup/popup.html
+++ b/popup/popup.html
@@ -23,10 +23,10 @@
                     <img id="dividing-line-img" src="/resources/line.png"/>
                 </td>
                 <td class="button-cell">
-                    <button class="controls-button" id="search-prev-button" title="Previous" type="button"/>
+                    <button class="controls-button" id="search-prev-button" title="Previous" type="button" disabled/>
                 </td>
                 <td class="button-cell">
-                    <button class="controls-button" id="search-next-button" title="Next" type="button"/>
+                    <button class="controls-button" id="search-next-button" title="Next" type="button" disabled/>
                 </td>
                 <td class="button-cell">
                     <button class="controls-button" id="close-button" title="Close find+ bar" type="button"/>

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -17,8 +17,7 @@ window.onload = function addListeners() {
             document.getElementById('extension-message-body').style.display = 'initial';
             document.getElementById('extension-limitation-chrome-settings-text').style.display = 'initial';
         }
-        else
-        {
+        else {
             chrome.tabs.executeScript( {
                 code: "window.getSelection().toString();"
             }, function(selection) {
@@ -120,7 +119,7 @@ function storeDataToLocalStorage(payload) {
 //Retrieve locally stored payload to be handled by handleDataFromStorage()
 function retrieveLastSearch() {
     chrome.storage.local.get('payload', function(data) {
-        handleDataFromStorage(data)
+        handleDataFromStorage(data);
     });
 }
 
@@ -130,6 +129,8 @@ function handleDataFromStorage(data) {
     var previousSearchText = storagePayload.previousSearch;
 
     changeSearchFieldText(previousSearchText);
+    if(previousSearchText.length > 0)
+        enableButtons();
 }
 
 //gets previous search text and sets it to search field text, then selects search field

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var port = chrome.runtime.connect({name: "popup_to_backend_port"});
+var initialized = false;
 
 //Load event listeners for popup components
 window.onload = function addListeners() {
@@ -63,6 +64,8 @@ port.onMessage.addListener(function listener(response) {
 
 //Perform update action
 function updateHighlight() {
+    initialized = true;
+    
     var regex = getSearchFieldText();
     var action = 'update';
     invokeAction({action: action, regex: regex});
@@ -70,6 +73,11 @@ function updateHighlight() {
 
 //Highlight next occurrence of regex
 function nextHighlight() {
+    if(!initialized) {
+        updateHighlight();
+        return;
+    }
+
     var action = 'next';
     invokeAction({action: action});
     document.getElementById('search-field').focus();
@@ -77,6 +85,11 @@ function nextHighlight() {
 
 //Highlight previous occurrence of regex
 function previousHighlight() {
+    if(!initialized) {
+        updateHighlight();
+        return;
+    }
+
     var action = 'previous';
     invokeAction({action: action});
     document.getElementById('search-field').focus();


### PR DESCRIPTION
##### Case 1:
If you open the native tool and the search field is empty, the seek buttons are disabled. In our extension, the buttons used to be enabled when the extension opens. This PR addresses this issue by ensuring that the seek buttons are disabled by default if there is no text in the search field.

##### Case 2:
If the search field contains text (from previous search), the native tool seek buttons are enabled and clicking them will show the index text and highlight if the text appears in the page. In our extension, if the search field contained the last search, clicking the buttons has no effect. Now, clicking the seek buttons will invoke the update action if needed.