### PR TITLE
Remove Search Field Autocomplete

### DIFF
--- a/popup/popup.html
+++ b/popup/popup.html
@@ -13,7 +13,7 @@
         <table id="popup-body-table">
             <tr>
                 <td id="field-cell">
-                    <input class="field" id="search-field" type="text" name="search" title="Search Field"/>
+                    <input class="field" id="search-field" type="text" name="search" title="Search Field" autocomplete="off"/>
                 </td>
                 <td id="index-text-cell">
                     <span id="index-text"></span>


### PR DESCRIPTION
Occasionally, as the user types text into the search field, the field provides autocomplete suggestions. However, the drop down is clipped and not useful.

This PR addresses the issue by removing the autocomplete feature completely.