### PR TITLE
Show Message for URLs Ending with .PDF

### DIFF
--- a/popup/extension.css
+++ b/popup/extension.css
@@ -115,7 +115,8 @@ table#message-table {
 }
 
 span#extension-limitation-web-store-text,
-span#extension-limitation-chrome-settings-text {
+span#extension-limitation-chrome-settings-text,
+span#extension-limitation-pdf-fileview-text{
     color: #FF0000;
     display: none;
 }

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -47,6 +47,9 @@
                     <span id="extension-limitation-chrome-settings-text">Oops! It appears you are trying to
                     use the extension in the 'chrome://' namespace. Developers at Google have blocked extensions from executing
                     here to prevent the malicious injection of code. This is a security limitation across all Chrome extensions.</span>
+                    <span id="extension-limitation-pdf-fileview-text">Oops! It appears you are trying to use the extension in a
+                    PDF document. Unfortunately, due to the complexity of the PDF viewer our extension is not able to handle searching through a PDF.
+                    We recommend using the native tool instead.</span>
                 </td>
             </tr>
         </table>

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -22,6 +22,10 @@ window.onload = function addListeners() {
             document.getElementById('extension-message-body').style.display = 'initial';
             document.getElementById('extension-limitation-chrome-settings-text').style.display = 'initial';
         }
+        else if(url.match(/.*\.pdf$/i)) {
+            document.getElementById('extension-message-body').style.display = 'initial';
+            document.getElementById('extension-limitation-pdf-fileview-text').style.display = 'initial';
+        }
         else {
             chrome.tabs.executeScript( {
                 code: "window.getSelection().toString();"


### PR DESCRIPTION
## Fixes https://github.com/brandon1024/find/issues/128

Our extension is limited to working only in web pages and text files. The extension is not able to search through PDF files.

It would be beneficial to display a small message to the user if they try to use the extension while viewing a page with the url ending in .PDF, similar to the message for loading the extension in the chrome:// namespace.

### Changes Proposed in this Pull Request:
- Added a PDF fileview limitation message in the popup, triggered by urls ending in `.pdf`

### Additional Comments and Documentation:
