### PR TITLE
Offline File Search Error Message

### DIFF
--- a/content/content.js
+++ b/content/content.js
@@ -11,6 +11,8 @@ browser.runtime.onMessage.addListener(function(message, sender, sendResponse) {
         sendResponse({success: true});
     else if(message.action == 'restore')
         sendResponse({success: restoreWebPage(message.uuids)});
+    else if(message.action == 'poll')
+        sendResponse({success: true});
     else
         return false;
 

--- a/popup/messagepane.css
+++ b/popup/messagepane.css
@@ -22,7 +22,7 @@ img#exclamation-icon {
     padding: 10px;
 }
 
-img#invalid-regex-icon {
+img.extension-error-icon {
     width: 10px;
     height: 10px;
     float: right;

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -19,7 +19,8 @@
                 </td>
                 <td id="index-text-cell">
                     <span class="def-font" id="index-text"></span>
-                    <img id="invalid-regex-icon" src="/resources/exclamation.svg" title="Malformed Regex:&#013;The regular expression entered is not acceptable, as it is either:&#013;&#09;- an invalid regular expression, or&#013;&#09;- not supported according to the Javascript RegExp specification"/>
+                    <img class="extension-error-icon" id="invalid-regex-icon" src="/resources/exclamation.svg" title="Malformed Regex:&#013;The regular expression entered is not acceptable, as it is either:&#013;&#09;- an invalid regular expression, or&#013;&#09;- not supported according to the Javascript RegExp specification"/>
+                    <img class="extension-error-icon" id="offline-file-search-err" src="/resources/exclamation.svg" title="Offline File Search:&#013;Something went wrong internally while trying to search this offline file. Luckily, we might know how to fix this. Try this:&#013;&#09;Navigate to 'chrome://extensions'.&#013;&#09;Locate the checkbox 'Allow access to file URLs' under the {find+} extension."/>
                 </td>
                 <td id="divide-line-cell">
                     <img id="dividing-line-img" src="/resources/line.png"/>

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -65,8 +65,11 @@ window.onload = function addListeners() {
         }
         else if(url.match(/^file:\/\/.*/i)) {
             browser.tabs.sendMessage(tabs[0].id, {action: 'poll'}, function (response) {
-                if(!response || !response.success)
+                if(!response || !response.success) {
                     showOfflineFileErrorIcon(true);
+                    updateIndexText();
+                    enableButtons(false);
+                }
                 else
                     getSelectedOrLastSearch();
             });


### PR DESCRIPTION
## Fixes #140 

### Changes Proposed in this Pull Request:
- When using the extension in offline web pages, the extension will not highlighting results on the page if the `Allow extension in file URLs` checkbox is not enabled in chrome extension settings. This can be misleading and cause the user to believe the extension is broken.
- To mitigate this issue, I have added a check in the popup script to check if the scripts are loaded in a `file://` URL. An error icon and tooltip is shown with more information.
