### PR TITLE
Treat <br/> as Block Element

### DIFF
--- a/content/content.js
+++ b/content/content.js
@@ -241,6 +241,10 @@ function isInlineLevelElement(element) {
         'br','img','map','object','q','script','span','sub','sup','button',
         'input','label','select','textarea'];
 
+    //Special case: will treat br as block element
+    if(elementTagName == 'br')
+        return false;
+
     for(var index = 0; index < inlineElements.length; index++)
         if(elementTagName == inlineElements[index])
             return true;


### PR DESCRIPTION
## Fixes #147 

### Changes Proposed in this Pull Request:
- Added special clause in `isInlineLevelElement(node)` to treat the `<br/>` element as a block level element instead of inline. This ensures that text that is broken into paragraphs with the break element will correctly highlight and match text.

### Additional Comments and Documentation:
Tested on https://www.senate.gov/legislative/LIS/roll_call_lists/roll_call_vote_cfm.cfm?congress=115&session=1&vote=00195 with regex `D.*Yea`
