### PR TITLE
Persistent Highlight Feature

### DIFF
--- a/backend/backend.js
+++ b/backend/backend.js
@@ -6,6 +6,7 @@ window.browser = (function () {
 
 var DOMModelObject = null;
 var regexOccurrenceMap = null;
+var options = null;
 var index = null;
 var regex = null;
 
@@ -35,6 +36,8 @@ browser.runtime.onConnect.addListener(function(port) {
         return;
 
     browser.tabs.query({active: true, currentWindow: true}, function (tabs) {
+        browser.tabs.sendMessage(tabs[0].id, {action: 'highlight_restore'});
+
         //Invoke action on message from popup script
         port.onMessage.addListener(function (message) {
             invokeAction(message.action, port, tabs[0].id, message);
@@ -42,7 +45,9 @@ browser.runtime.onConnect.addListener(function(port) {
 
         //Handle extension close
         port.onDisconnect.addListener(function() {
-            browser.tabs.sendMessage(tabs[0].id, {action: 'highlight_restore'});
+            if(!options || !options.persistent_highlights)
+                browser.tabs.sendMessage(tabs[0].id, {action: 'highlight_restore'});
+
             var uuids = getUUIDsFromModelObject(DOMModelObject);
             browser.tabs.sendMessage(tabs[0].id, {action: 'restore', uuids: uuids});
 
@@ -83,7 +88,7 @@ function actionUpdate(port, tabID, message) {
             if(!DOMModelObject)
                 return;
 
-            var options = message.options;
+            options = message.options;
             regex = message.regex;
 
             //If searching by string, escape all regex metacharacters
@@ -133,7 +138,7 @@ function actionUpdate(port, tabID, message) {
 
 //Action Next
 function actionNext(port, tabID, message) {
-    var options = message.options;
+    options = message.options;
     var indexCap = options.max_results != 0;
 
     //If reached end, reset index
@@ -151,7 +156,7 @@ function actionNext(port, tabID, message) {
 
 //Action Previous
 function actionPrevious(port, tabID, message) {
-    var options = message.options;
+    options = message.options;
     var indexCap = options.max_results != 0;
 
     //If reached start, set index to last occurrence

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -109,6 +109,21 @@
                         </span>
                     </td>
                 </tr>
+                <tr id="regex-options-table-row-3">
+                    <td class="options-table-toggle-cell">
+                        <label class="switch">
+                            <input id="regex-option-persistent-highlights-toggle" type="checkbox"/>
+                            <div class="toggle-slider"/>
+                        </label>
+                    </td>
+                    <td>
+                        <span id="regex-option-persistent-highlights-text" class="options-text">
+                            Persistent Highlights
+                            <img class="information-hover-icon" src="/resources/question-circle.svg"
+                                 title="If enabled, highlights in the web page will remain after the extension closes.&#013;Remove the highlights by reloading the page or reopening the extension."/>
+                        </span>
+                    </td>
+                </tr>
             </tbody>
         </table>
         <div id="regex-options-max-results-container">

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -5,7 +5,7 @@ window.browser = (function () {
 })();
 
 var port = browser.runtime.connect({name: 'popup_to_backend_port'});
-var options = {'find_by_regex': true, 'match_case': true, 'max_results': 0};
+var options = {'find_by_regex': true, 'match_case': true, 'persistent_highlights': false, 'max_results': 0};
 var initialized = false;
 var index = 0;
 
@@ -18,6 +18,7 @@ window.onload = function addListeners() {
     document.getElementById('search-field').addEventListener('input', updateSavedPreviousSearch);
     document.getElementById('regex-option-regex-disable-toggle').addEventListener('change', updateOptions);
     document.getElementById('regex-option-case-insensitive-toggle').addEventListener('change', updateOptions);
+    document.getElementById('regex-option-persistent-highlights-toggle').addEventListener('change', updateOptions);
     document.getElementById('max-results-slider').addEventListener('input', updateOptions);
     document.getElementById('replace-next-button').addEventListener('click', replaceNext);
     document.getElementById('replace-all-button').addEventListener('click', replaceAll);
@@ -199,6 +200,7 @@ function retrieveSavedOptions() {
 
         document.getElementById('regex-option-regex-disable-toggle').checked = options.find_by_regex;
         document.getElementById('regex-option-case-insensitive-toggle').checked = options.match_case;
+        document.getElementById('regex-option-persistent-highlights-toggle').checked = options.persistent_highlights;
 
         var rangeValues = [1,10,25,50,75,100,150,200,300,400,0];
         if(options.max_results == 0)
@@ -214,6 +216,7 @@ function retrieveSavedOptions() {
 function updateOptions() {
     options.find_by_regex = document.getElementById('regex-option-regex-disable-toggle').checked;
     options.match_case = document.getElementById('regex-option-case-insensitive-toggle').checked;
+    options.persistent_highlights = document.getElementById('regex-option-persistent-highlights-toggle').checked;
 
     var rangeValues = [1,10,25,50,75,100,150,200,300,400,0];
     var rangeIndex = document.getElementById('max-results-slider').value;


### PR DESCRIPTION
## Fixes #154 

### Changes Proposed in this Pull Request:
- Added UI slider in options pane for enabling persistent highlights
- Implemented logic in background script to only restore highlights if option is disabled
- Added highlight restore at port connect to remove any highlights that may have existed in the DOM on extension open (used to easily remove persisted highlights on extension open without the need to reload the page)

### Additional Comments and Documentation:
