### PR TITLE
Omnibox Support

### DIFF
--- a/content/highlighter.js
+++ b/content/highlighter.js
@@ -14,6 +14,10 @@ browser.runtime.onMessage.addListener(function(message, sender, response) {
             highlightAll(message.occurrenceMap, message.regex, message.options);
             seekHighlight(message.index);
             break;
+        case 'omni_update':
+            restore(yellowHighlightClass, orangeHighlightClass);
+            highlightAll(message.occurrenceMap, message.regex, null);
+            break;
         case 'highlight_seek':
             restoreClass(orangeHighlightClass);
             seekHighlight(message.index);
@@ -49,9 +53,13 @@ function highlightAll(occurrenceMap, regex, options) {
         }
     }};
 
-    tags.maxIndex = options.max_results == 0 ? null : options.max_results - 1;
+    if(options && options.max_results != 0)
+        tags.maxIndex = options.max_results - 1;
+    else
+        tags.maxIndex = null;
+
     regex = regex.replace(/ /g, '\\s');
-    if(options.match_case)
+    if(!options || options.match_case)
         regex = new RegExp(regex, 'm');
     else
         regex = new RegExp(regex, 'mi');

--- a/manifest.json
+++ b/manifest.json
@@ -38,6 +38,7 @@
       "css": ["/content/highlighter.css"]
     }
   ],
+  "omnibox": { "keyword" : "find" },
   "commands": {
     "_execute_browser_action": {
       "suggested_key": {

--- a/manifest_firefox.json
+++ b/manifest_firefox.json
@@ -36,6 +36,7 @@
       "css": ["/content/highlighter.css"]
     }
   ],
+  "omnibox": { "keyword" : "find" },
   "commands": {
     "_execute_browser_action": {
       "suggested_key": {


### PR DESCRIPTION
## Fixes #161 

### Changes Proposed in this Pull Request:
- Implemented Omnibox support
- Typing `find` and pressing `TAB` will allow you to type a regular expression in the bar and highlight occurrences on the page
- Pressing enter will remove the extension markup, but leave the highlights.
- To remove the highlights, reload the page or type `find` in the omnibox and press `TAB`.

### Additional Comments and Documentation:
