### PR TITLE
Content Script Autoinjection Bug Fix

### DIFF
--- a/backend/backend.js
+++ b/backend/backend.js
@@ -1,6 +1,7 @@
 "use strict";
 
 //Support Chrome and Firefox
+window.browser_id = typeof browser !== "undefined" ? "Firefox" : "Chrome";
 window.browser = (() => {
     return window.chrome || window.browser;
 })();
@@ -13,8 +14,12 @@ let regex = null;
 
 let installed = null;
 
-//Inject content scripts into pages on installed (not performed automatically)
+//Inject content scripts into pages on installed (not performed automatically in Chrome)
 browser.runtime.onInstalled.addListener((details) => {
+    if(browser_id === "Firefox") {
+        return;
+    }
+
     installed = {details: details};
 
     let manifest = browser.runtime.getManifest();


### PR DESCRIPTION
## Fixes #211 

Fixed bug that cause the content script autoinjection feature to break on firefox when the extension is first installed.

The reason this was occurring was because content scripts are automatically injected into existing pages in Firefox, but not in Chrome. Therefore, the autoinjection code was causing issues with duplicate injections in Firefox.

Added a simple check to make sure that the code is skipped in firefox.