### PR TITLE
Iframe Warning Icon

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -21,6 +21,10 @@
     "message": "Unable to copy to the clipboard due to unexpected error.",
     "description": "Tooltip text for the clipboard copy error icon."
   },
+  "iframes_found_warning_title": {
+    "message": "One or more iframes were encountered in the page. As a result, some occurrences of your search query may not be highlighted in the page.",
+    "description": "Tooltip text for the iframes encountered warning icon."
+  },
   "clipboard_copy_title": {
     "message": "Regex occurrence copied to clipboard.",
     "description": "Tooltip text for the clipboard copy successful icon."

--- a/background/background.js
+++ b/background/background.js
@@ -64,6 +64,7 @@ Find.register("Background", function(self) {
             if(resp.isReachable) {
                 resp.selectedText = response.selection;
                 resp.regex = response.regex;
+                resp.iframes = response.iframes;
                 index = response.index || 0;
             }
 

--- a/content/highlighter.js
+++ b/content/highlighter.js
@@ -49,7 +49,8 @@ Find.register('Content.Highlighter', function(self) {
                     success: true,
                     selection: window.getSelection().toString(),
                     regex: regex,
-                    index: index
+                    index: index,
+                    iframes: document.getElementsByTagName('iframe').length
                 });
                 return true;
         }

--- a/popup/js/browser-action.js
+++ b/popup/js/browser-action.js
@@ -53,23 +53,28 @@ Find.register('Popup.BrowserAction', function (self) {
         let url = initInformation.activeTab.url;
         if(isWithinChromeNamespace(url)) {
             Find.Popup.MessagePane.showChromeNamespaceErrorMessage();
-            Find.Popup.BrowserAction.error('forbidden_url');
+            self.error('forbidden_url');
         } else if(isWithinWebStoreNamespace(url)) {
             Find.Popup.MessagePane.showChromeWebStoreErrorMessage();
-            Find.Popup.BrowserAction.error('forbidden_url');
+            self.error('forbidden_url');
         } else if(isPDF(url)) {
             Find.Popup.MessagePane.showPDFSearchErrorMessage();
-            Find.Popup.BrowserAction.error('pdf_unsupported');
+            self.error('pdf_unsupported');
         } else if(isLocalFile(url) && !initInformation.isReachable) {
             Find.Popup.MessagePane.showOfflineFileErrorMessage();
-            Find.Popup.BrowserAction.error('offline_file');
+            self.error('offline_file');
         } else {
+            if(initInformation.iframes > 0) {
+                Find.Popup.SearchPane.flashIframesFoundWarningIcon();
+            }
+
             if(initInformation.selectedText) {
                 Find.Popup.SearchPane.setSearchFieldText(initInformation.selectedText);
                 Find.Popup.SearchPane.selectSearchField();
                 self.updateSearch();
             } else if(initInformation.regex != null) {
                 Find.Popup.SearchPane.setSearchFieldText(initInformation.regex);
+                Find.Popup.SearchPane.selectSearchField();
                 self.updateSearch();
             } else {
                 Find.Popup.Storage.retrieveHistory((data) => {
@@ -109,7 +114,7 @@ Find.register('Popup.BrowserAction', function (self) {
      * */
     self.seekForwards = function() {
         if(!initialized) {
-            Find.Popup.BrowserAction.updateSearch();
+            self.updateSearch();
             return;
         }
 
@@ -125,7 +130,7 @@ Find.register('Popup.BrowserAction', function (self) {
      * */
     self.seekBackwards = function() {
         if(!initialized) {
-            Find.Popup.BrowserAction.updateSearch();
+            self.updateSearch();
             return;
         }
 
@@ -157,7 +162,7 @@ Find.register('Popup.BrowserAction', function (self) {
      * */
     self.followLink = function() {
         if(!initialized) {
-            Find.Popup.BrowserAction.updateSearch();
+            self.updateSearch();
             return;
         }
 
@@ -172,7 +177,7 @@ Find.register('Popup.BrowserAction', function (self) {
      * */
     self.getOccurrence = function(options) {
         if(!initialized) {
-            Find.Popup.BrowserAction.updateSearch();
+            self.updateSearch();
             return;
         }
 
@@ -186,15 +191,9 @@ Find.register('Popup.BrowserAction', function (self) {
      * */
     self.copyTextToClipboard = function(text) {
         navigator.clipboard.writeText(text).then(() => {
-            Find.Popup.SearchPane.showClipboardCopyIcon(true);
-            window.setTimeout(() => {
-                Find.Popup.SearchPane.showClipboardCopyIcon(false);
-            }, 1000);
+            Find.Popup.SearchPane.flashClipboardCopyIcon();
         }).catch(() => {
-            Find.Popup.SearchPane.showClipboardCopyErrorIcon(true);
-            window.setTimeout(() => {
-                Find.Popup.SearchPane.showClipboardCopyIcon(false);
-            }, 2000);
+            Find.Popup.SearchPane.flashClipboardCopyErrorIcon();
         });
     };
 
@@ -234,57 +233,14 @@ Find.register('Popup.BrowserAction', function (self) {
     /**
      * Momentarily display the install/update icon in the search pane.
      *
-     * The icon will be shown for 3000ms, and will be hidden unless the user hovers the mouse over the icon to
-     * display the tooltip. In this case, the internal timer will be reset and the icon will remain visible for
-     * another 3000ms.
-     *
-     * Once the icon disappears, the event handlers are removed.
-     *
      * @param {object} details - A simple object containing a single key 'reason', with the value 'install' or 'update'.
      * */
     self.showInstallUpdateDetails = function(details) {
-        let el = null;
         if(details.reason === 'install') {
-            el = document.getElementById('install-information');
+            Find.Popup.SearchPane.flashInstallInformationIcon();
         } else if(details.reason === 'update') {
-            el = document.getElementById('update-information');
-        } else {
-            return;
+            Find.Popup.SearchPane.flashUpdateInformationIcon();
         }
-
-        let timeoutFunction = () => {
-            el.style.display = 'none';
-        };
-
-        //Show information icon
-        el.style.display = 'initial';
-
-        //Hide icon after 3 seconds
-        let timeoutHandle = window.setTimeout(timeoutFunction, 3000);
-
-        //Self de-registering event handler
-        let handler = (event) => {
-            if(el === event.target) {
-                return;
-            }
-
-            timeoutFunction();
-            window.clearTimeout(timeoutHandle);
-            document.getElementById('popup-body').removeEventListener('click', handler);
-            document.getElementById('popup-body').removeEventListener('keyup', handler);
-        };
-
-        //Add event listeners
-        document.getElementById('popup-body').addEventListener('click', handler);
-        document.getElementById('popup-body').addEventListener('keyup', handler);
-
-        el.addEventListener('mouseover', () => {
-            window.clearTimeout(timeoutHandle);
-        });
-
-        el.addEventListener('mouseout', () => {
-            timeoutHandle = window.setTimeout(timeoutFunction, 3000);
-        });
     };
 
     /**

--- a/popup/js/search-pane.js
+++ b/popup/js/search-pane.js
@@ -121,7 +121,7 @@ Find.register('Popup.SearchPane', function (self) {
     };
 
     /**
-     * Display an error icon in the index text to notify the user that the regex is invalid.
+     * Display an error icon in the notification area to notify the user that the regex is invalid.
      *
      * @param {boolean} flag - Whether or not to display the icon.
      * */
@@ -130,7 +130,7 @@ Find.register('Popup.SearchPane', function (self) {
     };
 
     /**
-     * Display an error icon in the index text to notify the user that the extension does not have
+     * Display an error icon in the notification area to notify the user that the extension does not have
      * permission to search in offline files.
      *
      * @param {boolean} flag - Whether or not to display the icon.
@@ -140,24 +140,96 @@ Find.register('Popup.SearchPane', function (self) {
     };
 
     /**
-     * Display an icon in the index text to notify the user that text was copied to the clipboard
+     * Momentarily display an icon in the notification area to notify the user that text was copied to the clipboard
      * successfully.
-     *
-     * @param {boolean} flag - Whether or not to display the icon.
      * */
-    self.showClipboardCopyIcon = function(flag) {
-        document.getElementById('clipboard-copy-icon').style.display = flag ? 'initial' : 'none';
+    self.flashClipboardCopyIcon = function() {
+        let el = document.getElementById('clipboard-copy-icon');
+        flashElement(el);
     };
 
     /**
-     * Display an icon in the index text to notify the user that text was not copied to the clipboard
+     * Momentarily display an icon in the inotification area to notify the user that text was not copied to the clipboard
      * due to an unexpected error.
-     *
-     * @param {boolean} flag - Whether or not to display the icon.
      * */
-    self.showClipboardCopyErrorIcon = function(flag) {
-        document.getElementById('clipboard-copy-error').style.display = flag ? 'initial' : 'none';
+    self.flashClipboardCopyErrorIcon = function() {
+        let el = document.getElementById('clipboard-copy-error');
+        flashElement(el);
     };
+
+    /**
+     * Momentarily display an icon in the notification area to notify the user that an iframe was encountered, and
+     * that some occurrences of the regex may not be highlighted in the page.
+     * */
+    self.flashIframesFoundWarningIcon = function() {
+        let el = document.getElementById('iframes-found-icon');
+        flashElement(el);
+    };
+
+    /**
+     * Momentarily display an icon in the notification area to provide an installation message to the user.
+     * */
+    self.flashInstallInformationIcon = function() {
+        let el = document.getElementById('install-information');
+        flashElement(el);
+    };
+
+    /**
+     * Momentarily display an icon in the notification area to provide update information message to the user.
+     * */
+    self.flashUpdateInformationIcon = function() {
+        let el = document.getElementById('update-information');
+        flashElement(el);
+    };
+
+    /**
+     * Momentarily display an icon or element. This is primarily used for flashing
+     * notification information in the search pane.
+     *
+     * The icon will be shown for 3000ms, and will be hidden unless the user hovers the mouse over the icon to
+     * display the tooltip. In this case, the internal timer will be reset and the icon will remain visible for
+     * another 3000ms.
+     *
+     * Once the icon disappears, the event handlers are removed.
+     *
+     * @private
+     * @param {Element} el - The element to flash
+     * */
+    function flashElement(el) {
+        let timeoutFunction = () => {
+            el.style.display = 'none';
+        };
+
+        //Show information icon
+        el.style.display = 'initial';
+
+        //Hide icon after 3 seconds
+        let timeoutHandle = window.setTimeout(timeoutFunction, 3000);
+
+        //Self de-registering event handler
+        let handler = (event) => {
+            if(el === event.target) {
+                return;
+            }
+
+            timeoutFunction();
+            window.clearTimeout(timeoutHandle);
+            document.getElementById('popup-body').removeEventListener('click', handler);
+            document.getElementById('popup-body').removeEventListener('keyup', handler);
+        };
+
+        //Add event listeners
+        document.getElementById('popup-body').addEventListener('click', handler);
+        document.getElementById('popup-body').addEventListener('keyup', handler);
+
+        el.addEventListener('mouseover', () => {
+            window.clearTimeout(timeoutHandle);
+        });
+
+        el.addEventListener('mouseout', () => {
+            timeoutHandle = window.setTimeout(timeoutFunction, 3000);
+        });
+    }
 
     /**
      * Format a number as a string with thousands separators.

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -33,6 +33,8 @@
                              data-locale-title="malformed_regex_error_title"/>
                         <img class="extension-error-icon" id="clipboard-copy-error" src="/resources/exclamation.svg"
                              data-locale-title="clipboard_copy_error_title"/>
+                        <img class="extension-error-icon" id="iframes-found-icon" src="/resources/exclamation.svg"
+                             data-locale-title="iframes_found_warning_title"/>
                         <img class="extension-error-icon" id="clipboard-copy-icon" src="/resources/check-square.svg"
                              data-locale-title="clipboard_copy_title"/>
                         <img class="extension-error-icon" id="install-information" src="/resources/question-circle.svg"


### PR DESCRIPTION
## Fixes #240 

### Changes Proposed in this Pull Request:
Added a warning icon to the search pane notification area that is
flashed when an iframe is encountered in the page. This is used to
indicate to the user that it's likely that some occurrences of their
search query will not be highlighted in the page.

In the future, when traversing same-origin iframes is implemented,
this will be adapted to only show warnings when iframes that are
not on the same origin are encountered.

In this commit, some logic was moved from the browser action namespace
into the search pane namespace to improve cohesion. Some logic was also
removed to utilize already existing logic.
