### PR TITLE
Firefox Bug Fix

### DIFF
--- a/app.js
+++ b/app.js
@@ -18,7 +18,7 @@ const Find = (function () {
     })();
 
     self.browser = (() => {
-        return window.chrome || window.browser;
+        return typeof chrome === 'undefined' ? browser : chrome;
     })();
 
     self.incognito = (() => {


### PR DESCRIPTION
## Fixes #255 

In v2.0.0, the extension won't open in Firefox due to a bug in app.js
that causes the window.chrome namespace to be used rather than the
window.browser namespace. Firefox supports both namespaces, and because
of this, the wrong namespace was being used.