### PR TITLE
Allow Options through Omnibox

### DIFF
--- a/background/omni.js
+++ b/background/omni.js
@@ -6,25 +6,6 @@
  * */
 Find.register("Background.Omni", function(self) {
 
-    let options = {
-        find_by_regex: true,
-        match_case: true,
-        persistent_highlights: false,
-        max_results: 0,
-        index_highlight_color: {
-            hue: 34,
-            saturation: 0.925,
-            value: 1,
-            hexColor: '#ff9813'
-        },
-        all_highlight_color: {
-            hue: 56,
-            saturation: 1,
-            value: 1,
-            hexColor: '#fff000'
-        }
-    };
-
     Find.browser.omnibox.setDefaultSuggestion({description: 'Enter a regular expression'});
 
     Find.browser.omnibox.onInputStarted.addListener(() => {
@@ -34,8 +15,10 @@ Find.register("Background.Omni", function(self) {
     });
 
     Find.browser.omnibox.onInputChanged.addListener((regex) => {
-        Find.browser.tabs.query({active: true, currentWindow: true}, (tabs) => {
-            Find.Background.updateSearch({regex: regex, options: options}, tabs[0], () => {});
+        retrieveOptions((options) => {
+            Find.browser.tabs.query({active: true, currentWindow: true}, (tabs) => {
+                Find.Background.updateSearch({regex: regex, options: options}, tabs[0], () => {});
+            });
         });
     });
 
@@ -46,4 +29,50 @@ Find.register("Background.Omni", function(self) {
     Find.browser.omnibox.onInputEntered.addListener(() => {
         Find.Background.restorePageState(false);
     });
+
+    /**
+     * Default options. This object and all of it's properties are immutable.
+     * To use this object, it must be cloned into a mutable object.
+     *
+     * To clone this object:
+     * let mutableOptions = JSON.parse(JSON.stringify(DEFAULT_OPTIONS));
+     * */
+    const DEFAULT_OPTIONS = Object.freeze({
+        find_by_regex: true,
+        match_case: true,
+        persistent_highlights: false,
+        persistent_storage_incognito: false,
+        max_results: 0,
+        index_highlight_color: Object.freeze({
+            hue: 34,
+            saturation: 0.925,
+            value: 1,
+            hexColor: '#ff9813'
+        }),
+        all_highlight_color: Object.freeze({
+            hue: 56,
+            saturation: 1,
+            value: 1,
+            hexColor: '#fff000'
+        })
+    });
+
+    /**
+     * Retrieve the search options from the browser local storage, and pass
+     * to the callback function. The data from the storage is passed as a single
+     * argument to the callback function.
+     *
+     * @param {function} callback - The callback function to handle the data.
+     * @return {object} The search history, or null if it does not exist or cannot be retrieved.
+     * */
+    function retrieveOptions(callback) {
+        Find.browser.storage.local.get('options', (data) => {
+            let options = data['options'];
+            if(!options) {
+                return callback(JSON.parse(JSON.stringify(DEFAULT_OPTIONS)));
+            }
+
+            callback(options);
+        });
+    }
 });


### PR DESCRIPTION
In v2, the omni.js used default options and disregarded the
user-configured options through the options pane. Some users have asked
whether they could use the configured options through the omnibox, so I
have opted to allow it.

Rather than replicate the storage mechanism between the popup and
background, I implemented a custom storage access function in the omni
namespace for accessing options. It's not perfect, there's some code
duplication here, but it's better than the alternative.

## Fixes #263 
## Fixes #261  
