### PR TITLE
Focus Search Field on Popup Start

### DIFF
--- a/popup/js/browser-action.js
+++ b/popup/js/browser-action.js
@@ -37,6 +37,8 @@ Find.register('Popup.BrowserAction', function (self) {
         document.getElementById('popup-body').addEventListener('click', () => {
             Find.Popup.SearchPane.focusSearchField();
         });
+
+        Find.Popup.SearchPane.focusSearchField();
     };
 
     /**


### PR DESCRIPTION
Occasionally the search field did not gain focus when the extension
popup started. To fix this, I added a focus line in the
browser-action.js init.
