### PR TITLE
Option to Hide Options/History Buttons

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -85,6 +85,14 @@
     "message": "If enabled, history and options will be persisted in regular and incognito sessions. If disabled, no session information will be saved while incognito.",
     "description": "Tooltip text for the persistent storage incognito option description icon."
   },
+  "extension_option_hide_option_pane_toggle_button_title": {
+    "message": "If enabled, the button used to toggle the option pane will be hidden.\nThe keyboard shortcuts may still be used to display or hide the pane.",
+    "description": "Tooltip text for the hide option pane toggle button option description icon."
+  },
+  "extension_option_hide_history_pane_toggle_button_title": {
+    "message": "If enabled, the button used to toggle the history pane will be hidden.\nThe keyboard shortcuts may still be used to display or hide the pane.",
+    "description": "Tooltip text for the hide history pane toggle button option description icon."
+  },
   "history_entry_icon_title": {
     "message": "Load this regex",
     "description": "Tooltip text for a history entry icon."
@@ -156,6 +164,14 @@
   "extension_option_persistent_storage_incognito_text": {
     "message": "Persistent Storage (Incognito)",
     "description": "Text displayed beside the persistent storage option."
+  },
+  "extension_option_hide_option_pane_toggle_button_text": {
+    "message": "Hide Option Pane Toggle Button",
+    "description": "Text displayed beside the hide option pane toggle button option."
+  },
+  "extension_option_hide_history_pane_toggle_button_text": {
+    "message": "Hide History Pane Toggle Button",
+    "description": "Text displayed beside the hide history pane toggle button option."
   },
   "search_option_max_results_text": {
     "message": "Max Highlighted Results",

--- a/background/omni.js
+++ b/background/omni.js
@@ -42,6 +42,8 @@ Find.register("Background.Omni", function(self) {
         match_case: true,
         persistent_highlights: false,
         persistent_storage_incognito: false,
+        hide_options_button: false,
+        hide_history_button: false,
         max_results: 0,
         index_highlight_color: Object.freeze({
             hue: 34,

--- a/popup/css/extension.css
+++ b/popup/css/extension.css
@@ -71,6 +71,7 @@ button.text-btn.warn {
 
 /* Controls Button */
 button.controls-button {
+    display: block;
     background: transparent no-repeat center;
     border-width: 0;
     border-radius: 2px;

--- a/popup/css/searchpane.css
+++ b/popup/css/searchpane.css
@@ -60,7 +60,7 @@ button.controls-button#search-toggle-options-button {
     background-size: 12px 12px;
 }
 
-button.controls-button#history-toggle-button {
+button.controls-button#search-history-toggle-button {
     background-image: url(/resources/bookmark.svg);
     background-size: 12px 12px;
 }

--- a/popup/js/options-pane.js
+++ b/popup/js/options-pane.js
@@ -17,6 +17,8 @@ Find.register('Popup.OptionsPane', function (self) {
         match_case: true,
         persistent_highlights: false,
         persistent_storage_incognito: false,
+        hide_options_button: false,
+        hide_history_button: false,
         max_results: 0,
         index_highlight_color: Object.freeze({
             hue: 34,
@@ -70,6 +72,16 @@ Find.register('Popup.OptionsPane', function (self) {
             Find.Popup.Storage.lockStorage(false);
             Find.Popup.Storage.saveOptions(options);
             Find.Popup.Storage.lockStorage(!options.persistent_storage_incognito);
+        });
+        document.getElementById('hide-option-pane-toggle-option-toggle').addEventListener('change', (e) => {
+            options.hide_options_button = e.target.checked;
+            Find.Popup.Storage.saveOptions(options);
+            Find.Popup.SearchPane.hideOptionsPaneToggleButton(options.hide_options_button);
+        });
+        document.getElementById('hide-history-pane-toggle-option-toggle').addEventListener('change', (e) => {
+            options.hide_history_button = e.target.checked;
+            Find.Popup.Storage.saveOptions(options);
+            Find.Popup.SearchPane.hideHistoryPaneToggleButton(options.hide_history_button);
         });
 
         //Add max results slider event listeners
@@ -302,6 +314,14 @@ Find.register('Popup.OptionsPane', function (self) {
             newOptions.persistent_storage_incognito = defaultOptions.persistent_storage_incognito;
         }
 
+        if(newOptions.hide_options_button === undefined) {
+            newOptions.hide_options_button = defaultOptions.hide_options_button;
+        }
+
+        if(newOptions.hide_history_button === undefined) {
+            newOptions.hide_history_button = defaultOptions.hide_history_button;
+        }
+
         if(newOptions.max_results === undefined) {
             newOptions.max_results = defaultOptions.max_results;
         }
@@ -355,6 +375,11 @@ Find.register('Popup.OptionsPane', function (self) {
         document.getElementById('regex-option-case-insensitive-toggle').checked = options.match_case;
         document.getElementById('regex-option-persistent-highlights-toggle').checked = options.persistent_highlights;
         document.getElementById('regex-option-persistent-storage-incognito-toggle').checked = options.persistent_storage_incognito;
+        document.getElementById('hide-option-pane-toggle-option-toggle').checked = options.hide_options_button;
+        document.getElementById('hide-history-pane-toggle-option-toggle').checked = options.hide_history_button;
+
+        Find.Popup.SearchPane.hideOptionsPaneToggleButton(options.hide_options_button);
+        Find.Popup.SearchPane.hideHistoryPaneToggleButton(options.hide_history_button);
     }
 
     /**

--- a/popup/js/search-pane.js
+++ b/popup/js/search-pane.js
@@ -48,7 +48,7 @@ Find.register('Popup.SearchPane', function (self) {
         }, true);
 
 
-        document.getElementById('history-toggle-button').addEventListener('click', () => {
+        document.getElementById('search-history-toggle-button').addEventListener('click', () => {
             Find.Popup.HistoryPane.toggle();
             Find.Popup.ReplacePane.show(false);
             Find.Popup.OptionsPane.show(false);
@@ -180,6 +180,24 @@ Find.register('Popup.SearchPane', function (self) {
     self.flashUpdateInformationIcon = function() {
         let el = document.getElementById('update-information');
         flashElement(el);
+    };
+
+    /**
+     * Show or hide the button used to toggle the options pane.
+     *
+     * @param {boolean} hide - If true, hides the button. Otherwise makes the button visible.
+     * */
+    self.hideOptionsPaneToggleButton = function(hide) {
+        document.getElementById('search-toggle-options-button').style.display = hide ? 'none' : 'initial';
+    };
+
+    /**
+     * Show or hide the button used to toggle the history pane.
+     *
+     * @param {boolean} hide - If true, hides the button. Otherwise makes the button visible.
+     * */
+    self.hideHistoryPaneToggleButton = function(hide) {
+        document.getElementById('search-history-toggle-button').style.display = hide ? 'none' : 'initial';
     };
 
     /**

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -47,26 +47,16 @@
 
                 <!--  Area for search controls, such as seek, toggle options or history, and close extension -->
                 <div id="search-controls-container">
-                    <div class="controls-button-cell">
-                        <button class="controls-button" id="search-prev-button" type="button" disabled
-                                data-locale-title="search_prev_title"/>
-                    </div>
-                    <div class="controls-button-cell">
-                        <button class="controls-button" id="search-next-button" type="button" disabled
-                                data-locale-title="search_next_title"/>
-                    </div>
-                    <div class="controls-button-cell">
-                        <button class="controls-button" id="search-toggle-options-button" type="button"
-                                data-locale-title="toggle_options_pane_title"/>
-                    </div>
-                    <div class="controls-button-cell">
-                        <button class="controls-button" id="history-toggle-button" type="button"
-                                data-locale-title="toggle_history_button"/>
-                    </div>
-                    <div class="controls-button-cell">
-                        <button class="controls-button" id="close-button" type="button"
-                                data-locale-title="close_extension_title"/>
-                    </div>
+                    <button class="controls-button" id="search-prev-button" type="button" disabled
+                            data-locale-title="search_prev_title"/>
+                    <button class="controls-button" id="search-next-button" type="button" disabled
+                            data-locale-title="search_next_title"/>
+                    <button class="controls-button" id="search-toggle-options-button" type="button"
+                            data-locale-title="toggle_options_pane_title"/>
+                    <button class="controls-button" id="search-history-toggle-button" type="button"
+                            data-locale-title="toggle_history_button"/>
+                    <button class="controls-button" id="close-button" type="button"
+                            data-locale-title="close_extension_title"/>
                 </div>
             </div>
         </div>
@@ -174,6 +164,36 @@
                                   data-locale-text="extension_option_persistent_storage_incognito_text"></span>
                             <img class="information-hover-icon" src="/resources/question-circle.svg"
                                  data-locale-title="extension_option_persistent_storage_incognito_title"/>
+                        </td>
+                    </tr>
+
+                    <!-- Hide Options Pane Toggle Button -->
+                    <tr>
+                        <td class="options-table-toggle-cell">
+                            <label class="switch">
+                                <input id="hide-option-pane-toggle-option-toggle" type="checkbox"/>
+                                <div class="toggle-slider"/>
+                            </label>
+                        </td>
+                        <td>
+                            <span class="def-font" data-locale-text="extension_option_hide_option_pane_toggle_button_text"></span>
+                            <img class="information-hover-icon" src="/resources/question-circle.svg"
+                                 data-locale-title="extension_option_hide_option_pane_toggle_button_title"/>
+                        </td>
+                    </tr>
+
+                    <!-- Hide History Pane Toggle Button -->
+                    <tr>
+                        <td class="options-table-toggle-cell">
+                            <label class="switch">
+                                <input id="hide-history-pane-toggle-option-toggle" type="checkbox"/>
+                                <div class="toggle-slider"/>
+                            </label>
+                        </td>
+                        <td>
+                            <span class="def-font" data-locale-text="extension_option_hide_history_pane_toggle_button_text"></span>
+                            <img class="information-hover-icon" src="/resources/question-circle.svg"
+                                 data-locale-title="extension_option_hide_history_pane_toggle_button_title"/>
                         </td>
                     </tr>
                 </tbody>


### PR DESCRIPTION
## Fixes #271 

Implemented two new options which allow the options/history toggle
buttons in the search pane to be hidden. The panes may still be toggled
using the keyboard shortcuts.