### PR TITLE
Switch Tabs Highlights Fix

### DIFF
--- a/background/background.js
+++ b/background/background.js
@@ -104,22 +104,21 @@ Find.register("Background", function(self) {
      * Remove any highlights and markup from the active tab in the current window. Also resets
      * any state variables, such as the current index, document representation and occurrence map.
      *
+     * @param {object} tab - Information about the active tab in the current window.
      * @param {boolean} [restoreHighlights] - If undefined or true, remove highlights. If false,
      * highlights are not removed, and are persisted in the page.
      * */
-    self.restorePageState = function(restoreHighlights) {
-        Find.browser.tabs.query({active: true, currentWindow: true}, (tabs) => {
-            if(restoreHighlights === undefined || restoreHighlights) {
-                Find.Background.ContentProxy.clearPageHighlights(tabs[0]);
-            }
+    self.restorePageState = function(tab, restoreHighlights) {
+        if(restoreHighlights === undefined || restoreHighlights) {
+            Find.Background.ContentProxy.clearPageHighlights(tab);
+        }
 
-            let uuids = getUUIDsFromModelObject(documentRepresentation);
-            Find.Background.ContentProxy.restoreWebPage(tabs[0], uuids);
+        let uuids = getUUIDsFromModelObject(documentRepresentation);
+        Find.Background.ContentProxy.restoreWebPage(tab, uuids);
 
-            documentRepresentation = null;
-            regexOccurrenceMap = null;
-            index = null;
-        });
+        documentRepresentation = null;
+        regexOccurrenceMap = null;
+        index = null;
     };
 
     /**
@@ -159,7 +158,6 @@ Find.register("Background", function(self) {
             }
 
             //Build occurrence map, reposition index if necessary
-            console.log(index);
             regexOccurrenceMap = buildOccurrenceMap(documentRepresentation, regex, self.options);
             if(index > regexOccurrenceMap.length-1) {
                 if(regexOccurrenceMap.length !== 0) {

--- a/background/omni.js
+++ b/background/omni.js
@@ -6,28 +6,31 @@
  * */
 Find.register("Background.Omni", function(self) {
 
+    let activeTab = null;
+
     Find.browser.omnibox.setDefaultSuggestion({description: 'Enter a regular expression'});
 
     Find.browser.omnibox.onInputStarted.addListener(() => {
         Find.browser.tabs.query({active: true, currentWindow: true}, (tabs) => {
-            Find.Background.initializePage(tabs[0]);
+            activeTab = tabs[0];
+            Find.Background.initializePage(activeTab);
         });
     });
 
     Find.browser.omnibox.onInputChanged.addListener((regex) => {
         retrieveOptions((options) => {
-            Find.browser.tabs.query({active: true, currentWindow: true}, (tabs) => {
-                Find.Background.updateSearch({regex: regex, options: options}, tabs[0], () => {});
-            });
+            Find.Background.updateSearch({regex: regex, options: options}, activeTab, () => {});
         });
     });
 
     Find.browser.omnibox.onInputCancelled.addListener(() => {
-        Find.Background.restorePageState();
+        Find.Background.restorePageState(activeTab);
+        activeTab = null;
     });
 
     Find.browser.omnibox.onInputEntered.addListener(() => {
-        Find.Background.restorePageState(false);
+        Find.Background.restorePageState(activeTab, false);
+        activeTab = null;
     });
 
     /**


### PR DESCRIPTION
## Fixes #275 

When switching tabs with the extension open and a search in progress,
highlights injected into the page are not removed as expected. To fix
this, tab queries for the current active tab were removed and tabs were
only querried when the browser action port is established.