### PR TITLE
Scroll to center instead of top when searching

### DIFF
--- a/content/highlighter.js
+++ b/content/highlighter.js
@@ -251,7 +251,7 @@ Find.register('Content.Highlighter', function(self) {
             els[elsIndex].setAttribute("style", style);
         }
 
-        els[0].scrollIntoView(true);
+        els[0].scrollIntoView({block: 'center'});
 
         let docHeight = Math.max(document.documentElement.clientHeight, document.documentElement.offsetHeight, document.documentElement.scrollHeight);
         let bottomScrollPos = window.pageYOffset + window.innerHeight;


### PR DESCRIPTION
## Fixes #

### Changes Proposed in this Pull Request:
- When going to the next highlight result, make sure it's in the middle of the page instead of at the top

### Additional Comments and Documentation:

In addition to making it easier to see the context of the search result, this also fixes the issue where the popup sometimes overlaps with the search result.

This might not be something you wish to merge, it's a bit of a personal preference. It could also be a setting I guess but I personally find this method far easier.

To illustrate, before the search result is invisible (ignore the fact that I've made the search field a bit bigger):

![image](https://user-images.githubusercontent.com/270571/57261945-4c45d500-706a-11e9-9bb5-f62587cc79ec.png)


After:

![image](https://user-images.githubusercontent.com/270571/57261974-713a4800-706a-11e9-8b06-ee1bf5d0b815.png)
