### PR TITLE
Implemented Host-Specific History for Persisting Latest Search Queries

### DIFF
--- a/background/browser-action-proxy.js
+++ b/background/browser-action-proxy.js
@@ -27,6 +27,11 @@ Find.register("Background.BrowserActionProxy", function() {
             browserActionPort.onMessage.addListener((message) => {
                 actionDispatch(message, activeTab, (resp) => {
                     browserActionPort.postMessage(resp);
+
+                    // only build the DOM representation object after the browser action is initialized
+                    if (message.action === 'browser_action_init') {
+                        Find.Background.initializePage(activeTab);
+                    }
                 });
             });
 
@@ -40,8 +45,6 @@ Find.register("Background.BrowserActionProxy", function() {
 
                 activeTab = null;
             });
-
-            Find.Background.initializePage(activeTab);
         });
     });
 

--- a/popup/js/browser-action.js
+++ b/popup/js/browser-action.js
@@ -53,6 +53,10 @@ Find.register('Popup.BrowserAction', function (self) {
      * */
     self.startExtension = function(initInformation) {
         let url = initInformation.activeTab.url;
+
+        // this is the only time we have the active window hostname
+        Find.Popup.History.setHostname(new URL(url).hostname);
+
         if(isWithinChromeNamespace(url)) {
             Find.Popup.MessagePane.showChromeNamespaceErrorMessage();
             self.error('forbidden_url');
@@ -79,9 +83,9 @@ Find.register('Popup.BrowserAction', function (self) {
                 Find.Popup.SearchPane.selectSearchField();
                 self.updateSearch();
             } else {
-                Find.Popup.Storage.retrieveSavedExpressions((data) => {
-                    if(data && data.length) {
-                        Find.Popup.SearchPane.setSearchFieldText(data[0]);
+                Find.Popup.History.retrieveForHost((expression) => {
+                    if (expression) {
+                        Find.Popup.SearchPane.setSearchFieldText(expression);
                     }
 
                     Find.Popup.SearchPane.selectSearchField();
@@ -107,6 +111,7 @@ Find.register('Popup.BrowserAction', function (self) {
         let regex = Find.Popup.SearchPane.getSearchFieldText();
         let options = Find.Popup.OptionsPane.getOptions();
         Find.Popup.BackgroundProxy.postMessage({action: 'update', regex: regex, options: options});
+        Find.Popup.History.saveForHost(regex);
     };
 
     /**

--- a/popup/js/history.js
+++ b/popup/js/history.js
@@ -1,0 +1,140 @@
+'use strict';
+
+/**
+ * Create the Popup History namespace.
+ *
+ * This namespace is responsible for retrieving and persisting previous search
+ * queries for specific hosts. It's mostly a facade for the Find.Popup.Storage
+ * API that has caching capabilities and logic for pruning old history.
+ * */
+Find.register('Popup.History', function (self) {
+
+	let cachedHistory = null;
+	let currentHostname = null;
+
+	/**
+	 * Since the hostname is only available when the popup is initialized,
+	 * the hostname can be set here at initialization time and so it can
+	 * be referenced later.
+	 *
+	 * @param {string} hostname - The hostname of the current page in the active tab.
+	 * */
+	self.setHostname = function (hostname) {
+		currentHostname = hostname;
+	};
+
+	/**
+	 * Retrieve the last search query for the current host, passing the
+	 * result to the given callback function.
+	 *
+	 * If the current hostname is not set, or no history data exists for
+	 * this host, null is passed to the callback.
+	 *
+	 * @param {function} callback - The callback function, accepting a single
+	 * argument that is the last known search query for this host, or null
+	 * if current hostname is not set, or no such information exists.
+	 * */
+	self.retrieveForHost = function(callback) {
+		if (!currentHostname) {
+			callback();
+			return;
+		}
+
+		Find.Popup.Storage.retrieveHistory((history) => {
+			if (history && history[currentHostname]) {
+				callback(history[currentHostname].expression);
+
+				cachedHistory = history;
+			} else {
+				callback(null);
+			}
+		});
+	};
+
+	/**
+	 * Update the history entry for the current host with the new expression,
+	 * invoking the given callback when the operation is complete.
+	 *
+	 * If the number of history entries for all hosts exceeds 100, old queries
+	 * are pruned.
+	 *
+	 * @param {string} expression - The query/expression to save for the current host
+	 * @param {function} callback - The optional callback function invoked when the
+	 * operation is complete.
+	 * */
+	self.saveForHost = function(expression, callback) {
+		if (callback) {
+			callback = () => {};
+		}
+
+		if (!currentHostname) {
+			callback();
+			return;
+		}
+
+		// if we cached the history, don't bother fetching from local storage
+		if (cachedHistory) {
+			cachedHistory[currentHostname] = {
+				expression: expression,
+				timestamp: Date.now()
+			};
+
+			// prune and save
+			cachedHistory = prune(cachedHistory);
+			Find.Popup.Storage.saveHistory(cachedHistory, callback);
+		} else {
+			Find.Popup.Storage.retrieveHistory((history) => {
+				if (!history) {
+					history = {};
+				}
+
+				history[currentHostname] = {
+					expression: expression,
+					timestamp: Date.now()
+				};
+
+				history = prune(history);
+
+				Find.Popup.Storage.saveHistory(history, () => {
+					cachedHistory = history;
+					callback();
+				});
+			});
+		}
+	};
+
+	/**
+	 * Prune old search history data to avoid exceeding localstorage space
+	 * limitations.
+	 *
+	 * History will only be pruned if the number of entries exceeds 100. If
+	 * exceeded, the oldest entries will be removed.
+	 *
+	 * @private
+	 * @param {object} history - History data.
+	 * @return {object} Pruned history data.
+	 * */
+	function prune(history) {
+		// only prune of number of items is over 100
+		if (history && Object.keys(history).length <= 100)
+			return history;
+
+		let temporary = [];
+		for (let key in history) {
+			temporary.push({k: key, v: history[key]});
+		}
+
+		temporary.sort((a, b) => {
+			return a.v.timestamp - b.v.timestamp;
+		});
+
+		temporary = temporary.slice((temporary.length - 100), temporary.length);
+
+		let prunedHistory = {};
+		for (let element of temporary) {
+			prunedHistory[element.k] = element.v;
+		}
+
+		return prunedHistory;
+	}
+});

--- a/popup/js/replace-pane.js
+++ b/popup/js/replace-pane.js
@@ -72,7 +72,7 @@ Find.register('Popup.ReplacePane', function (self) {
     /**
      * Select all the text in the replace field.
      * */
-    self.selectSearchField = function() {
+    self.selectReplaceField = function() {
         document.getElementById('replace-field').select();
     };
 

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -11,6 +11,7 @@
         <script type="text/javascript" src="js/options-pane.js"></script>
         <script type="text/javascript" src="js/replace-pane.js"></script>
         <script type="text/javascript" src="js/message-pane.js"></script>
+        <script type="text/javascript" src="js/history.js"></script>
         <script type="text/javascript" src="js/saved-expressions-pane.js"></script>
         <script type="text/javascript" src="js/browser-action.js"></script>
         <link rel="stylesheet" href="css/extension.css"/>


### PR DESCRIPTION
## Fixes #272 

### Changes Proposed in this Pull Request:
Created a new interface for retrieving and persisting search query
information for specific hosts. This is used to populate the search
field with the last search query for the current host.

This revision also addresses the extension popup slowness during
initialization. Browser initialization and page tokenization was
conflicting, where parsing the DOM was computationally expensive and
slowing down the initialization response to the browser action. Now, the
browser action is more responsive.
