### PR TITLE
Improvements to Scrolling When Seeking

### DIFF
--- a/content/highlighter.js
+++ b/content/highlighter.js
@@ -251,12 +251,15 @@ Find.register('Content.Highlighter', function(self) {
             els[elsIndex].setAttribute("style", style);
         }
 
-        els[0].scrollIntoView(true);
+        // only scroll if the element is not in the current viewport
+        if (!isElementInViewport(els[0])) {
+            els[0].scrollIntoView(true);
 
-        let docHeight = Math.max(document.documentElement.clientHeight, document.documentElement.offsetHeight, document.documentElement.scrollHeight);
-        let bottomScrollPos = window.pageYOffset + window.innerHeight;
-        if (bottomScrollPos + 100 < docHeight) {
-            window.scrollBy(0, -100);
+            let docHeight = Math.max(document.documentElement.clientHeight, document.documentElement.offsetHeight, document.documentElement.scrollHeight);
+            let bottomScrollPos = window.pageYOffset + window.innerHeight;
+            if (bottomScrollPos + 100 < docHeight) {
+                window.scrollBy(0, -100);
+            }
         }
     };
 
@@ -345,4 +348,21 @@ Find.register('Content.Highlighter', function(self) {
             }
         }
     };
+
+    function isElementInViewport(element) {
+        let elementBoundingRect = element.getBoundingClientRect();
+        if (elementBoundingRect.top < 0 || elementBoundingRect.left < 0) {
+            return false;
+        }
+
+        if (elementBoundingRect.bottom > (window.innerHeight || document.documentElement.clientHeight)) {
+            return false;
+        }
+
+        if (elementBoundingRect.right > (window.innerWidth || document.documentElement.clientWidth)) {
+            return false;
+        }
+
+        return true;
+    }
 });


### PR DESCRIPTION
## Fixes #259 

### Changes Proposed in this Pull Request:
Prior to this revision, seeking to the next or previous occurrent would
scroll the page regardless of whether the occurrence was in the current
viewport or not. This was frustrating for some users, so I improved the
logic to check if the next/previous element is in the viewport before
scrolling.