### PR TITLE
Ensure Clipboard Button Hidden by Default

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -182,8 +182,8 @@
     "description": "Text displayed beside the hide saved expressions pane toggle button option."
   },
   "extension_option_hide_copy_to_clipboard_toggle_button_text": {
-    "message": "Hide Copy To Clipboard Toggle Button",
-    "description": "Text displayed beside the hide copy to clipboard toggle button option."
+    "message": "Hide Copy To Clipboard Button",
+    "description": "Text displayed beside the hide copy to clipboard button option."
   },
   "search_option_max_results_text": {
     "message": "Max Highlighted Results",

--- a/popup/help.html
+++ b/popup/help.html
@@ -108,6 +108,9 @@
                         <h3>Hide Saved Expressions Pane Toggle Button</h3>
                         <p class="indent">This option can be used to hide the button used to toggle the saved expressions pane. If enabled, you will need to use the shortcut to toggle the pane.</p>
 
+                        <h3>Hide Copy To Clipboard Button</h3>
+                        <p class="indent">This option can be used to hide the button used to copy occurrences to the clipboard. If enabled, you will need to use the keyboard shortcut to copy occurrences.</p>
+
                         <h3>Max Highlighted Results</h3>
                         <p class="indent">Limit the number of occurrences in the page. When set, only the first few results will be highlighted.</p>
 

--- a/popup/js/options-pane.js
+++ b/popup/js/options-pane.js
@@ -43,7 +43,7 @@ Find.register('Popup.OptionsPane', function (self) {
     self.init = function() {
         Find.Popup.Storage.retrieveOptions((data) => {
             options = adaptOptions(data);
-            applyOptions(options);
+            applyOptions();
 
             Find.Popup.Storage.saveOptions(options);
             if(Find.incognito) {
@@ -234,7 +234,7 @@ Find.register('Popup.OptionsPane', function (self) {
         let resetAllOptionsButton = document.getElementById('reset-options-button');
         resetAllOptionsButton.addEventListener('click', () => {
             options = JSON.parse(JSON.stringify(DEFAULT_OPTIONS));
-            applyOptions(options);
+            applyOptions();
 
             Find.Popup.Storage.saveOptions(options);
             Find.Popup.BrowserAction.updateSearch();
@@ -280,9 +280,8 @@ Find.register('Popup.OptionsPane', function (self) {
      * Apply an object representing a set of options to the options pane.
      *
      * @private
-     * @param {object} newOptions - The options to apply to the options pane.
      * */
-    function applyOptions(newOptions) {
+    function applyOptions() {
         applyToggleOptions();
         applyMaxResultsSliderOptions();
         applyIndexHighlightColorSliderOptions();
@@ -304,43 +303,7 @@ Find.register('Popup.OptionsPane', function (self) {
         const defaultOptions = JSON.parse(JSON.stringify(DEFAULT_OPTIONS));
         newOptions = newOptions || {};
 
-        if(newOptions.find_by_regex === undefined) {
-            newOptions.find_by_regex = defaultOptions.find_by_regex;
-        }
-
-        if(newOptions.match_case === undefined) {
-            newOptions.match_case = defaultOptions.match_case;
-        }
-
-        if(newOptions.persistent_highlights === undefined) {
-            newOptions.persistent_highlights = defaultOptions.persistent_highlights;
-        }
-
-        if(newOptions.persistent_storage_incognito === undefined) {
-            newOptions.persistent_storage_incognito = defaultOptions.persistent_storage_incognito;
-        }
-
-        if(newOptions.hide_options_button === undefined) {
-            newOptions.hide_options_button = defaultOptions.hide_options_button;
-        }
-
-        if(newOptions.hide_saved_expressions_button === undefined) {
-            newOptions.hide_saved_expressions_button = defaultOptions.hide_saved_expressions_button;
-        }
-
-        if(newOptions.max_results === undefined) {
-            newOptions.max_results = defaultOptions.max_results;
-        }
-
-        if(newOptions.index_highlight_color === undefined) {
-            newOptions.index_highlight_color = defaultOptions.index_highlight_color;
-        }
-
-        if(newOptions.all_highlight_color === undefined) {
-            newOptions.all_highlight_color = defaultOptions.all_highlight_color;
-        }
-
-        return newOptions;
+        return Object.assign({}, defaultOptions, newOptions);
     }
 
     /**


### PR DESCRIPTION
## Fixes #292
When installing the extension for the first time, the "Hide Copy To
Clipboard Button" is disabled, so the button is incorrectly shown by default.
This is due to the defective adaptOptions() function.

Fixed adaptOptions, and also updated the help page to add info on this
option.
