### PR TITLE
Fix Saved Expression Feature

### DIFF
--- a/popup/js/history.js
+++ b/popup/js/history.js
@@ -63,7 +63,7 @@ Find.register('Popup.History', function (self) {
 	 * operation is complete.
 	 * */
 	self.saveForHost = function(expression, callback) {
-		if (callback) {
+		if (!callback) {
 			callback = () => {};
 		}
 

--- a/popup/js/saved-expressions-pane.js
+++ b/popup/js/saved-expressions-pane.js
@@ -81,9 +81,11 @@ Find.register('Popup.SavedExpressionsPane', function (self) {
 						break;
 					}
 				}
-
-				data.unshift(regex);
+			} else {
+				data = [];
 			}
+
+			data.unshift(regex);
 
 			//Add new entry as first child
 			let parentEl = document.getElementById('saved-expressions-entry-list');
@@ -102,6 +104,8 @@ Find.register('Popup.SavedExpressionsPane', function (self) {
 			if(nullEntry) {
 				nullEntry.parentNode.removeChild(nullEntry);
 			}
+
+			console.log(data);
 
 			Find.Popup.Storage.saveExpressions(data);
 		});


### PR DESCRIPTION
## Fixes #297 

### Changes Proposed in this Pull Request:
The saved expressions feature was failing to save new entries because
the data is not updated correctly. If the saved expressions did not
exist in local storage, nothing would be saved.

Also addressed a minor issue that caused an undefined callback to be
executed, which would throw an error.