### PR TITLE
F311: Improve Accessibility for Text Color in Highlights

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -150,7 +150,11 @@
     "description": "Text displayed in the message pane when the extension is used in an offline file without adequate permissions for parsing file contents."
   },
   "search_options_header_text": {
-    "message": "Regex Options",
+    "message": "Expression Options",
+    "description": "Header text displayed in the options pane."
+  },
+  "extension_options_header_text": {
+    "message": "Extension Options",
     "description": "Header text displayed in the options pane."
   },
   "saved_expressions_body_header": {

--- a/content/highlighter.js
+++ b/content/highlighter.js
@@ -29,7 +29,7 @@ Find.register('Content.Highlighter', function(self) {
 
                     //If reached max number of occurrences to show, don't highlight text
                     if (this.maxIndex == null || this.occIndex <= this.maxIndex) {
-                        let style = 'all: unset; background-color: ' + options.all_highlight_color.hexColor + ';';
+                        let style = 'all: unset; background-color: ' + options.all_highlight_color.hexColor + '; color: black;';
                         let classList = 'find-ext-occr' + index + ' ' + allHighlight;
                         this.openingMarkup = '<span style="' + style + '" class="' + classList + '">';
                         this.closingMarkup = '</span>';
@@ -234,7 +234,7 @@ Find.register('Content.Highlighter', function(self) {
         let previousIndex = Array.from(document.querySelectorAll('.' + indexHighlight));
         if (previousIndex && previousIndex.length) {
             for (let elsIndex = 0; elsIndex < previousIndex.length; elsIndex++) {
-                let style = 'all: unset; background-color: ' + options.all_highlight_color.hexColor + ';';
+                let style = 'all: unset; background-color: ' + options.all_highlight_color.hexColor + '; color: black;';
                 previousIndex[elsIndex].classList.remove(indexHighlight);
                 previousIndex[elsIndex].setAttribute("style", style);
             }
@@ -246,7 +246,7 @@ Find.register('Content.Highlighter', function(self) {
         }
 
         for (let elsIndex = 0; elsIndex < els.length; elsIndex++) {
-            let style = 'all: unset; background-color: ' + options.index_highlight_color.hexColor + ';';
+            let style = 'all: unset; background-color: ' + options.index_highlight_color.hexColor + '; color: black;';
             els[elsIndex].classList.add(indexHighlight);
             els[elsIndex].setAttribute("style", style);
         }

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -137,6 +137,15 @@
                                  data-locale-title="search_option_match_case_title"/>
                         </td>
                     </tr>
+                </tbody>
+            </table>
+
+            <table id="extension-options-table">
+                <tbody>
+                    <tr>
+                        <span class="pane-header" id="extension-options-header"
+                              data-locale-text="extension_options_header_text"></span>
+                    </tr>
 
                     <!-- Persistent Highlights Option -->
                     <tr>


### PR DESCRIPTION
Similar to the native tool, highlighted text is now colored black to
improve accessibility (constrast with highlight color).

## Fixes #311

### Changes Proposed in this Pull Request:
- highlighted text is now colored black for better contrast.
- minor improvements to options pane.

### Additional Comments and Documentation:
![image](https://user-images.githubusercontent.com/22732449/90981580-36e30b80-e538-11ea-8488-6326cc5b83ec.png)
![image](https://user-images.githubusercontent.com/22732449/90981590-495d4500-e538-11ea-9b2b-3f7439c389b2.png)

