### PR TITLE
Various Fixes and Improvements

### DIFF
--- a/background/background.js
+++ b/background/background.js
@@ -92,11 +92,15 @@ Find.register("Background", function(self) {
      * Initialize the extension by constructing the page document representation.
      *
      * @param {object} tab - Information about the active tab in the current window.
+     * @param {function} callback - Optional callback .
      * */
-    self.initializePage = function(tab) {
+    self.initializePage = function(tab, callback) {
         Find.Background.ContentProxy.buildDocumentRepresentation(tab, (model) => {
             documentRepresentation = model;
-            index = 0;
+
+            if (callback) {
+                callback();
+            }
         });
     };
 
@@ -139,6 +143,10 @@ Find.register("Background", function(self) {
     self.updateSearch = function(message, tab, sendResponse) {
         try {
             if(!documentRepresentation) {
+                self.initializePage(tab, () => {
+                    self.updateSearch(message, tab, sendResponse);
+                });
+
                 return;
             }
 

--- a/background/browser-action-proxy.js
+++ b/background/browser-action-proxy.js
@@ -23,19 +23,14 @@ Find.register("Background.BrowserActionProxy", function() {
         Find.browser.tabs.query({active: true, currentWindow: true}, (tabs) => {
             activeTab = tabs[0];
 
-            //Invoke action on message from popup script
+            // invoke action on message from popup script
             browserActionPort.onMessage.addListener((message) => {
                 actionDispatch(message, activeTab, (resp) => {
                     browserActionPort.postMessage(resp);
-
-                    // only build the DOM representation object after the browser action is initialized
-                    if (message.action === 'browser_action_init') {
-                        Find.Background.initializePage(activeTab);
-                    }
                 });
             });
 
-            //Handle extension close
+            // handle extension close
             browserActionPort.onDisconnect.addListener(() => {
                 if(!Find.Background.options || !Find.Background.options.persistent_highlights) {
                     Find.Background.restorePageState(activeTab);

--- a/content/content.js
+++ b/content/content.js
@@ -18,7 +18,6 @@ Find.register('Content', function(self) {
      * Register a message listener to the extension background script.
      * */
     Find.browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
-        //Parser Actions
         switch (message.action) {
             case 'init':
                 selected = window.getSelection().toString();

--- a/popup/js/browser-action.js
+++ b/popup/js/browser-action.js
@@ -89,6 +89,7 @@ Find.register('Popup.BrowserAction', function (self) {
                     }
 
                     Find.Popup.SearchPane.selectSearchField();
+                    self.updateSearch();
                 });
             }
         }


### PR DESCRIPTION
## Fixes #325
## Fixes #323
## Fixes #309

### Changes Proposed in this Pull Request:
* F325: Correct UpdateSearch for Fetch Document Representation if Unset
When the popup is opened with a saved search, pressing enter had no
effect. This has been corrected. The updateSearch function would return
if the DOM representation is missing, but the representation was never
set.

* F323: Correct Page Index Cache
We used to remember the search index in the page if the extension is
reopened, but there was a defect that would prevent this from working
properly (always set to 0).

* F309: Race Condition for Extension Initialization
There was a race condition that would cause the extension to fail to
load. This has been corrected.