### PR TITLE
F355: Remove clipboardWrite Permission

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -11,7 +11,6 @@
     "activeTab",
     "background",
     "storage",
-    "clipboardWrite",
     "contextMenus",
     "<all_urls>"
   ],

--- a/manifest_firefox.json
+++ b/manifest_firefox.json
@@ -10,7 +10,6 @@
     "tabs",
     "activeTab",
     "storage",
-    "clipboardWrite",
     "contextMenus",
     "<all_urls>"
   ],


### PR DESCRIPTION
## Fixes #355 

### Changes Proposed in this Pull Request:
- updated manifest to remove the clipboardWrite permission

### Additional Comments and Documentation:
The extension was removed by Google because of this extra permission. Will redeploy.