### PR TITLE
Fix example regex in the user guide

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -74,7 +74,7 @@
 						<div class="content-inner">
 							The following example matches any quoted date with the format "####-##-##".
 
-							<pre>"\d{4}-\d{2}-\d{d}"</pre>
+							<pre>"\d{4}-\d{2}-\d{2}"</pre>
 							<pre>
 {
     "Version": <span style="background-color: #ff9813">"2012-10-17"</span>,


### PR DESCRIPTION
The example regex on the user guide has a typo:
![image](https://user-images.githubusercontent.com/1833684/137830293-82210518-4ce1-4483-888e-23af6dd40c96.png)