### PR TITLE
UI: Chevron fix for collapsible content

### DIFF
--- a/docs/help.css
+++ b/docs/help.css
@@ -149,11 +149,11 @@ input[type='checkbox'] {
     border-left: 4px solid currentColor;
     vertical-align: middle;
     margin-right: .7rem;
-    transform: translateY(-2px);
+    transform: rotate(90deg) translateX(-3px);
 }
 
 .toggle:checked + .lbl-toggle::before {
-    transform: rotate(90deg) translateX(-3px);
+    transform: rotate(0deg) translateY(-3px);
 }
 
 .toggle:checked + .lbl-toggle + .collapsible-content {


### PR DESCRIPTION
## Fixes #

The UI/UX for the chevrons for the collapsible content was off.
Pointing right while open and down when closed.

### Changes Proposed in this Pull Request:
- Do a positive 90 degree rotate by default
- Revert to 0 degree on select

### Additional Comments and Documentation:
In my defense, I was bored and unsupervised, with access to the internet.
Thanks for all the hard work!
Hope you have a great weekend!