### PR TITLE
Improvements to text color and background color

### DIFF
--- a/docs/help.css
+++ b/docs/help.css
@@ -48,6 +48,7 @@ table tr:nth-child(2n) {
 
 div#body-container {
     background-color: white;
+    color: black;
     max-width: 800px;
     margin: auto;
     padding: 10px;

--- a/popup/css/extension.css
+++ b/popup/css/extension.css
@@ -3,6 +3,7 @@
 body {
     margin: 3px;
     width: 410px;
+    background-color: white;
 }
 
 div.pane {

--- a/popup/css/searchpane.css
+++ b/popup/css/searchpane.css
@@ -32,7 +32,7 @@ div#search-info {
 }
 
 span#index-text {
-    color: #CCCCCC;
+    color: #888888;
     white-space: nowrap;
     text-align: right;
 }


### PR DESCRIPTION
## Fixes #390; fixes #392

### Changes Proposed in this Pull Request:
- Set text color of the "User Guide" page to "black".
- Set the background-color of popup to "white".
- Darken the text of search index in popup.

### Additional Comments and Documentation:

Tested in the following two browsers on Windows 10 Pro 21H2 (19044.2486):

- Google Chrome Version 112.0.5579.0 (Official Build) canary (64-bit)
- Firefox Nightly 111.0a1 (2023-02-04) (64-bit) with user settings about the color (in "Settings" - "Language and Appearance" - "Colors"):
  - "Text" is "white",
  - "Background" is "black",
  - "Use system colors" is unchecked.

Comparison:

- Overall changes in this PR:

![20230206-Firefox-Extension-Find+-color-overall](https://user-images.githubusercontent.com/29089388/217018977-56265d99-f468-4f6a-b233-a7723138e2e4.png)

- For "Darken the text of search index in popup" (a4d0b52ea91198f7dc92d8e7d9f0b6bf46d4557a):

<!-- ![20230206-Firefox-Extension-Find+-color-search_index](https://user-images.githubusercontent.com/29089388/217019103-27b9d041-216c-4bf5-8e55-de593159648f.png) -->

![20230206-Firefox-Extension-Find+-color-search_index-Firefox-Chrome](https://user-images.githubusercontent.com/29089388/217021490-b979acca-d195-4cda-a9ef-1a70edf9b9a1.png)

The webpage I was opening:

- [Browser Toolbox — Firefox Source Docs documentation](https://firefox-source-docs.mozilla.org/devtools-user/browser_toolbox/index.html)

