### PR TITLE
Ignore the new url of Google Chrome Web Store

### DIFF
--- a/background/background.js
+++ b/background/background.js
@@ -43,7 +43,9 @@ Find.register("Background", function(self) {
             Find.browser.tabs.query({}, (tabs) => {
                 for(let tabIndex = 0; tabIndex < tabs.length; tabIndex++) {
                     let url = tabs[tabIndex].url;
-                    if(url.match(/chrome:\/\/.*/) || url.match(/https:\/\/chrome.google.com\/webstore\/.*/)) {
+                    if(url.match(/chrome:\/\/.*/)
+                        || url.match(/https:\/\/chrome\.google\.com\/webstore\/.*/)
+                        || url.match(/https:\/\/chromewebstore\.google\.com\/.*/)) {
                         continue;
                     }
 

--- a/popup/js/browser-action.js
+++ b/popup/js/browser-action.js
@@ -269,6 +269,7 @@ Find.register('Popup.BrowserAction', function (self) {
      * */
     function isWithinWebStoreNamespace(url) {
         return url.match(/https:\/\/chrome\.google\.com\/webstore\/.*/)
+            || url.match(/https:\/\/chromewebstore\.google\.com\/.*/)
             || url.match(/https:\/\/google\.[^\/]*\/_\/chrome\/newtab.*/);
     }
 


### PR DESCRIPTION
## Fixes https://github.com/brandon1024/find/issues/96#issuecomment-1834492694

### Changes Proposed in this Pull Request:

- ignore links like "https://chromewebstore.google.com/detail/fddffkdncgkkdjobemgbpojjeffmmofb".
- Minor fix for regex.

### Additional Comments and Documentation:

Undefined
