### PR TITLE
Change keyword to findplus

### DIFF
--- a/.github/PRIVACY.md
+++ b/.github/PRIVACY.md
@@ -1,0 +1,8 @@
+# Find+ Privacy Policy
+Find+ does not collect any data of any kind.
+
+- Find+ is run on the client, only. There are no external servers hosted to support this extension.
+- Find+ doesn't embed any kind of analytic or telemetry hooks in its code.
+- Find+ doesn't accept donations or any other form of financing.
+- Find+ doesn't make any web requests to any third party servers.
+

--- a/.github/README.md
+++ b/.github/README.md
@@ -48,7 +48,7 @@ When the extension popup is open, there are a number of keyboard shortcuts you c
 | <kbd>CTRL</kbd>+<kbd>↵</kbd> or <kbd>ESC</kbd>     | <kbd>^</kbd>+<kbd>↵</kbd> or <kbd>ESC</kbd>        | Close the extension popup                                              |
 
 ## Omnibox Support
-In version 1.4.0, we introduced omnibox support! This allows you to highlight text on a page without even opening the extension. To use this feature, type `find` in your browser's address bar, press <kbd>␣</kbd> or <kbd>⇥</kbd>, and then enter a regular expression. Occurrences of the regular expression will become highlighted on the page as you type.
+In version 1.4.0, we introduced omnibox support! This allows you to highlight text on a page without even opening the extension. To use this feature, type `findplus` in your browser's address bar, press <kbd>␣</kbd> or <kbd>⇥</kbd>, and then enter a regular expression. Occurrences of the regular expression will become highlighted on the page as you type.
 
 Pressing `ENTER` will leave the highlights in the page. To remove the highlights, simply refresh the page. If you don't want to leave the highlights in the page, just erase the text entered in the address bar.
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -1,11 +1,11 @@
 <img src="../resources/icon.png" align="right" width="128" />
 
 # **{find+}**
-![Chrome Users](https://img.shields.io/chrome-web-store/users/fddffkdncgkkdjobemgbpojjeffmmofb.svg?style=flat&label=chrome%20users)
-![Firefox Users](https://img.shields.io/amo/users/brandon1024-find.svg?label=firefox%20users&style=flat)
-![Last Commit on GitHub](https://img.shields.io/github/last-commit/brandon1024/find.svg?style=flat)
+[![Chrome Users](https://img.shields.io/chrome-web-store/users/fddffkdncgkkdjobemgbpojjeffmmofb.svg?style=flat&label=chrome%20users)](https://chrome.google.com/webstore/detail/find%2B/fddffkdncgkkdjobemgbpojjeffmmofb)
+[![Firefox Users](https://img.shields.io/amo/users/brandon1024-find.svg?label=firefox%20users&style=flat)](https://addons.mozilla.org/en-US/firefox/addon/brandon1024-find/)
+[![Last Commit on GitHub](https://img.shields.io/github/last-commit/brandon1024/find.svg?style=flat)](https://github.com/brandon1024/find/commits/develop)
 
-**{find+}** is a powerful _find-in-page_ extension for Chrome and Firefox that allows you to search for content in a web page or document by regular expression. It is a feature-rich alternative to the native _find-in-page_ tool built into your browser. 
+**{find+}** is a powerful _find-in-page_ extension for Chrome and Firefox that allows you to search for content in a web page or document by regular expression. It is a feature-rich alternative to the native _find-in-page_ tool built into your browser.
 
 Some notable features:
 - match a regular expression against text in a web page
@@ -25,7 +25,7 @@ The **{find+}** extension is available through the Chrome Web Store and through 
 <img src="firefox-icon.png" width="16"/> Download the extension here: [{find+} – Get this Extension for 🦊 Firefox](https://addons.mozilla.org/en-US/firefox/addon/brandon1024-find/).
 
 ## Keyboard Shortcuts
-In Firefox, you can use <kbd>CTRL</kbd>+<kbd>⇧</kbd>+<kbd>F</kbd> to open the extension popup. 
+In Firefox, you can use <kbd>CTRL</kbd>+<kbd>⇧</kbd>+<kbd>F</kbd> to open the extension popup.
 
 To open the extension popup in Chrome using a keyboard shortcut, you must first assign a keyboard shortcut to the extension through the Chrome settings. You can do this by following these steps:
 1. Navigate to the `Extensions` settings page in Chrome, or type `chrome://extensions/` into the navigation bar.

--- a/_locales/zh/messages.json
+++ b/_locales/zh/messages.json
@@ -1,233 +1,233 @@
 {
   "extension_name": {
-    "message": "find+ | Regex Find-in-Page Tool",
+    "message": "find+ | 正则页内查找工具",
     "description": "The extension name in the manifest file."
   },
   "extension_description": {
-    "message": "A find-in-page extension for Google Chrome with support for regular expressions.",
+    "message": "一个支持正则表达式的网页搜索插件",
     "description": "Short description of the extension in the manifest file."
   },
 
 
   "search_field_title": {
-    "message": "Search Field",
+    "message": "搜索字段",
     "description": "Tooltip text for the search field."
   },
   "malformed_regex_error_title": {
-    "message": "Malformed Regex:\nThe regular expression entered is not acceptable, as it is either an invalid regular expression, or not supported according to the Javascript RegExp specification",
+    "message": "错误的表达式:\n输入的表达式不被接受，因为不是有效的正则表达式或者不匹配Javascript正则规范。",
     "description": "Tooltip text for the invalid regex icon."
   },
   "clipboard_copy_error_title": {
-    "message": "Unable to copy to the clipboard due to unexpected error.",
+    "message": "未能复制到剪贴板，由于未知错误。",
     "description": "Tooltip text for the clipboard copy error icon."
   },
   "iframes_found_warning_title": {
-    "message": "One or more iframes were encountered in the page. As a result, some occurrences of your search query may not be highlighted in the page.",
+    "message": "该页有一个或多个框架，会导致你的搜索不被高亮显示",
     "description": "Tooltip text for the iframes encountered warning icon."
   },
   "clipboard_copy_title": {
-    "message": "Regex occurrence copied to clipboard.",
+    "message": "正则已复制到剪贴板。Regex occurrence copied to clipboard.",
     "description": "Tooltip text for the clipboard copy successful icon."
   },
   "installation_information_title": {
-    "message": "Welcome and thanks for installing our extension! Here are some tips to get you started:\n\tENTER : Advance to the next occurrence of the regular expression in the page\n\tSHIFT-ENTER : Return to the previous occurrence of the regular expression in the page\n\tCTRL-ALT-O : Expand or Collapse Options Pane\n\tCTRL-ALT-R : Expand or Collapse Replace Text Pane\n\tCTRL-ENTER or ESC : Close the extension popup",
+    "message": "欢迎并感谢安装我们的插件！这里有一些提示帮助你开始使用：\n\tENTER：查找下一个结果\n\tSHIFT-ENTER：返回上一个结果\n\tCTRL-ALT-0：展开或折叠可选面板\n\tCTRL-ALT-R：展开或折叠替代文本面板\n\tCTRL-ENTER 或 ESC：关闭插件弹窗",
     "description": "Tooltip text for the install information icon."
   },
   "update_information_title": {
-    "message": "We just updated the extension! Now it works better than ever :)\nCheck out our GitHub page for information about this update!",
+    "message": "我们更新了插件！现在它会工作的更好:)\n在我们的GitHub页查看这次的更新信息！",
     "description": "Tooltip text for the update information icon."
   },
   "search_prev_title": {
-    "message": "Previous",
+    "message": "上一个",
     "description": "Tooltip text for the seek backwards button."
   },
   "search_next_title": {
-    "message": "Next",
+    "message": "下一个",
     "description": "Tooltip text for the seek forwards button."
   },
   "toggle_options_pane_title": {
-    "message": "Toggle Options Pane",
+    "message": "设置窗口",
     "description": "Tooltip text for the toggle options pane button."
   },
   "toggle_saved_expressions_button": {
-    "message": "Show Saved Expressions",
+    "message": "保存的表达式",
     "description": "Tooltip text for the show saved expressions button."
   },
   "copy_to_clipboard_button_title": {
-    "message": "Copy All Occurrences To Clipboard",
+    "message": "复制所有结果到剪贴板",
     "description": "Tooltip text for the copy to clipboard button."
   },
   "toggle_find_replace_button_title": {
-    "message": "Find and Replace",
+    "message": "查找并替换",
     "description": "Tooltip text for the find and replace toggle button."
   },
   "close_extension_title": {
-    "message": "Close find+",
+    "message": "关闭find+",
     "description": "Tooltip text for the close extension button."
   },
   "replace_field_title": {
-    "message": "Replace Field",
+    "message": "替换失败了",
     "description": "Tooltip text for the replace field."
   },
   "replace_button_title": {
-    "message": "Replace Next",
+    "message": "替换下一个",
     "description": "Tooltip text for the replace next button."
   },
   "replace_all_button_title": {
-    "message": "Replace All",
+    "message": "替换所有",
     "description": "Tooltip text for the replace all button."
   },
   "search_option_find_by_regex_title": {
-    "message": "If enabled, text entered in the search field will be treated as a regular expression.\nIf disabled, the text is treated as string literal.",
+    "message": "如果启用，搜索框的输入文本将作为正则表达式。\n如果禁用，文本将会作为普通字符。",
     "description": "Tooltip text for the find by regex option description icon."
   },
   "search_option_match_case_title": {
-    "message": "If enabled, the case of characters must match that of the query string.\nIf disabled, the case of characters in the query string are not considered.",
+    "message": "如果启用，大小写字母必须匹配表达式。\n如果禁用，大小写字母不影响匹配。",
     "description": "Tooltip text for the match case option description icon."
   },
   "search_option_persistent_highlights_title": {
-    "message": "If enabled, highlights in the web page will remain after the extension closes.\nRemove the highlights by reloading the page or reopening the extension.",
+    "message": "如果启用，关闭插件后依然显示高亮。\n通过刷新或者重新打开网页取消高亮",
     "description": "Tooltip text for the persistent highlights option description icon."
   },
   "extension_option_persistent_storage_incognito_title": {
-    "message": "If enabled, searches and options will be persisted in regular and incognito sessions. If disabled, no session information will be saved while incognito.",
+    "message": "如果启用，搜索和选项将保留在常规和隐身会话中。如果禁用，则在隐身时不会保存任何会话信息。",
     "description": "Tooltip text for the persistent storage incognito option description icon."
   },
   "extension_option_hide_option_pane_toggle_button_title": {
-    "message": "If enabled, the button used to toggle the option pane will be hidden.\nThe keyboard shortcuts may still be used to display or hide the pane.",
+    "message": "如果启用，隐藏'设置窗口'的按钮。\n键盘快捷键仍可用于显示或隐藏该窗格。",
     "description": "Tooltip text for the hide option pane toggle button option description icon."
   },
   "extension_option_hide_saved_expressions_pane_toggle_button_title": {
-    "message": "If enabled, the button used to toggle the saved expressions pane will be hidden.\nThe keyboard shortcuts may still be used to display or hide the pane.",
+    "message": "如果启用，隐藏'保存的表达式'的按钮。\n键盘快捷键仍可用于显示或隐藏窗格。",
     "description": "Tooltip text for the hide saved expressions pane toggle button option description icon."
   },
   "extension_option_hide_copy_to_clipboard_toggle_button_title": {
-    "message": "If enabled, the button used to copy all occurrences to clipboard will be hidden.\nThe keyboard shortcuts may still be used to copy all occurrences to clipboard.",
+    "message": "如果启用，隐藏'复制到剪贴板'的按钮。\n键盘快捷方式仍可用于将所有匹配项复制到剪贴板。",
     "description": "Tooltip text for the copy all occurrences to clipboard button option description icon."
   },
   "extension_option_hide_find_replace_toggle_button_title": {
-    "message": "If enabled, the button used to toggle the Find and Replace pane will be hidden.\nThe keyboard shortcuts may still be used to display or hide the pane.",
+    "message": "如果启用，隐藏'查找和替换'窗格的按钮。\n键盘快捷键仍可用于显示或隐藏窗格。",
     "description": "Tooltip text for the hide find and replace pane toggle button option description icon."
   },
   "saved_expression_icon_title": {
-    "message": "Load this expression",
+    "message": "加载这个表达式",
     "description": "Tooltip text for a saved expression entry icon."
   },
   "delete_saved_expression_icon_title": {
-    "message": "Delete this expression",
+    "message": "删除这个表达式",
     "description": "Tooltip text for a delete saved expression entry icon."
   },
   "clear_expressions_button_title": {
-    "message": "Clear All Saved Expressions",
+    "message": "清除所有保存的表达式",
     "description": "Tooltip text for the clear saved expressions button."
   },
   "save_expression_button_title": {
-    "message": "Save Expression in Search Field",
+    "message": "保存搜索字段的表达式",
     "description": "Tooltip text for the save expression button."
   },
 
 
   "replace_field_placeholder": {
-    "message": "Replace with..",
+    "message": "替换为..",
     "description": "Placeholder text for the replace field."
   },
 
 
   "replace_button_text": {
-    "message": "Replace",
+    "message": "替换",
     "description": "Text displayed inside the replace button."
   },
   "replace_all_button_text": {
-    "message": "Replace All",
+    "message": "替换所有",
     "description": "Text displayed inside the replace all button."
   },
   "extension_limitation_web_store_text": {
-    "message": "Oops! It appears you are trying to use the extension in the Chrome Web Store. Developers at Google have blocked extensions from executing here to prevent the malicious injection of code. This is a security limitation across all Chrome extensions.",
+    "message": "哎呀！您似乎正在尝试在Chrome网上应用店中使用该插件。Google的开发人员已阻止插件在此处执行，以防止恶意注入代码。这是所有Chrome插件的安全限制。",
     "description": "Text displayed in the message pane when the extension is used in the Chrome Web Store."
   },
   "extension_limitation_chrome_namespace_text": {
-    "message": "Oops! It appears you are trying to use the extension in the 'chrome://' namespace. Developers at Google have blocked extensions from executing here to prevent the malicious injection of code. This is a security limitation across all Chrome extensions.",
+    "message": "哎呀！您似乎正在尝试在'chrome://'命名空间中使用插件。Google的开发人员已阻止插件在此处执行，以防止恶意注入代码。这是所有 Chrome 插件的安全限制。",
     "description": "Text displayed in the message pane when the extension is used in the chrome:// namespace."
   },
   "extension_limitation_pdf_text": {
-    "message": "Oops! It appears you are trying to use the extension in a PDF document. Unfortunately, due to the complexity of the PDF viewer our extension is not able to handle searching through a PDF. We recommend using the native tool instead.",
+    "message": "哎呀！您似乎正在尝试在 PDF 文档中使用插件名。不幸的是，由于PDF查看器的复杂性，我们的插件无法处理PDF搜索。我们建议改用本机工具。",
     "description": "Text displayed in the message pane when the extension is used in a PDF."
   },
   "extension_limitation_offline_file_text": {
-    "message": "Something went wrong internally while trying to search this offline file. Luckily, we might know how to fix this. Navigate to 'chrome://extensions' and locate the checkbox 'Allow access to file URLs' under the {find+} extension.",
+    "message": "尝试搜索此脱机文件时内部出现问题。幸运的是，我们可能知道如何解决这个问题。导航到'chrome://extensions'，然后在插件名{find+}下找到'允许访问文件URL'复选框。",
     "description": "Text displayed in the message pane when the extension is used in an offline file without adequate permissions for parsing file contents."
   },
   "search_options_header_text": {
-    "message": "Expression Options",
+    "message": "设置",
     "description": "Header text displayed in the options pane."
   },
   "extension_options_header_text": {
-    "message": "Extension Options",
+    "message": "插件选项",
     "description": "Header text displayed in the options pane."
   },
   "saved_expressions_body_header": {
-    "message": "Saved Expressions",
+    "message": "保存表达式",
     "description": "Header text displayed in the saved expressions pane."
   },
   "search_option_find_by_regex_text": {
-    "message": "Find by Regular Expression",
+    "message": "通过正则表达式查找",
     "description": "Text displayed beside the find by regex option."
   },
   "search_option_match_case_text": {
-    "message": "Match Case",
+    "message": "匹配大小写",
     "description": "Text displayed beside the match case option."
   },
   "search_option_persistent_highlights_text": {
-    "message": "Persistent Highlights",
+    "message": "持续高亮",
     "description": "Text displayed beside the persistent highlights option."
   },
   "extension_option_persistent_storage_incognito_text": {
-    "message": "Persistent Storage (Incognito)",
+    "message": "持续存储",
     "description": "Text displayed beside the persistent storage option."
   },
   "extension_option_hide_option_pane_toggle_button_text": {
-    "message": "Hide Option Pane Toggle Button",
+    "message": "隐藏'设置窗口'按钮",
     "description": "Text displayed beside the hide option pane toggle button option."
   },
   "extension_option_hide_saved_expressions_pane_toggle_button_text": {
-    "message": "Hide Saved Expressions Pane Toggle Button",
+    "message": "隐藏'保存的表达式'按钮",
     "description": "Text displayed beside the hide saved expressions pane toggle button option."
   },
   "extension_option_hide_copy_to_clipboard_toggle_button_text": {
-    "message": "Hide Copy To Clipboard Button",
+    "message": "隐藏'复制到剪贴板'按钮",
     "description": "Text displayed beside the hide copy to clipboard toggle button option."
   },
   "extension_option_hide_find_replace_toggle_button_text": {
-    "message": "Hide Find and Replace Pane Toggle Button",
+    "message": "隐藏'复制和替换'按钮",
     "description": "Text displayed beside the hide find and replace toggle button option."
   },
   "search_option_max_results_text": {
-    "message": "Max Highlighted Results",
+    "message": "最大高亮数量",
     "description": "Text displayed above the max highlighted results option."
   },
   "search_option_index_highlight_text": {
-    "message": "Selected Occurrence Highlight Color",
+    "message": "选中的高亮颜色",
     "description": "Text displayed above the index highlight color option."
   },
   "search_option_all_highlight_text": {
-    "message": "Highlight Color",
+    "message": "高亮颜色",
     "description": "Text displayed above the all highlight color option."
   },
   "reset_options_button_text": {
-    "message": "Reset All Options",
+    "message": "重置所有选项",
     "description": "Text displayed in the reset options button."
   },
 
   "no_expressions_found_text": {
-    "message": "No saved expressions found.",
+    "message": "没有找到保存的表达式",
     "description": "Text displayed in the saved expressions pane when no expressions exist."
   },
   "clear_expressions_button_text":{
-    "message": "Clear Saved Expressions",
+    "message": "清除保存的表达式",
     "description": "Text displayed in the saved expressions pane."
   },
   "save_expression_button_text":{
-    "message": "Save Expression",
+    "message": "保存表达式",
     "description": "Text displayed in the saved expressions pane."
   }
 }

--- a/_locales/zh/messages.json
+++ b/_locales/zh/messages.json
@@ -18,15 +18,15 @@
     "description": "Tooltip text for the invalid regex icon."
   },
   "clipboard_copy_error_title": {
-    "message": "未能复制到剪贴板，由于未知错误。",
+    "message": "未能复制到剪贴板，由于一些未知错误。",
     "description": "Tooltip text for the clipboard copy error icon."
   },
   "iframes_found_warning_title": {
-    "message": "该页有一个或多个框架，会导致你的搜索不被高亮显示",
+    "message": "该页有一个或多个框架，可能会导致搜索结果不被高亮显示",
     "description": "Tooltip text for the iframes encountered warning icon."
   },
   "clipboard_copy_title": {
-    "message": "正则已复制到剪贴板。Regex occurrence copied to clipboard.",
+    "message": "正则已复制到剪贴板。",
     "description": "Tooltip text for the clipboard copy successful icon."
   },
   "installation_information_title": {
@@ -66,7 +66,7 @@
     "description": "Tooltip text for the close extension button."
   },
   "replace_field_title": {
-    "message": "替换失败了",
+    "message": "替换字段",
     "description": "Tooltip text for the replace field."
   },
   "replace_button_title": {
@@ -90,7 +90,7 @@
     "description": "Tooltip text for the persistent highlights option description icon."
   },
   "extension_option_persistent_storage_incognito_title": {
-    "message": "如果启用，搜索和选项将保留在常规和隐身会话中。如果禁用，则在隐身时不会保存任何会话信息。",
+    "message": "如果启用，搜索和选项将保留在常规和隐身窗口中。如果禁用，则在使用隐身窗口时不会保存任何会话信息。",
     "description": "Tooltip text for the persistent storage incognito option description icon."
   },
   "extension_option_hide_option_pane_toggle_button_title": {
@@ -158,11 +158,11 @@
     "description": "Text displayed in the message pane when the extension is used in an offline file without adequate permissions for parsing file contents."
   },
   "search_options_header_text": {
-    "message": "设置",
+    "message": "正则设置",
     "description": "Header text displayed in the options pane."
   },
   "extension_options_header_text": {
-    "message": "插件选项",
+    "message": "插件设置",
     "description": "Header text displayed in the options pane."
   },
   "saved_expressions_body_header": {
@@ -198,7 +198,7 @@
     "description": "Text displayed beside the hide copy to clipboard toggle button option."
   },
   "extension_option_hide_find_replace_toggle_button_text": {
-    "message": "隐藏'复制和替换'按钮",
+    "message": "隐藏'查找和替换'按钮",
     "description": "Text displayed beside the hide find and replace toggle button option."
   },
   "search_option_max_results_text": {

--- a/background/background.js
+++ b/background/background.js
@@ -43,7 +43,9 @@ Find.register("Background", function(self) {
             Find.browser.tabs.query({}, (tabs) => {
                 for(let tabIndex = 0; tabIndex < tabs.length; tabIndex++) {
                     let url = tabs[tabIndex].url;
-                    if(url.match(/chrome:\/\/.*/) || url.match(/https:\/\/chrome.google.com\/webstore\/.*/)) {
+                    if(url.match(/chrome:\/\/.*/)
+                        || url.match(/https:\/\/chrome\.google\.com\/webstore\/.*/)
+                        || url.match(/https:\/\/chromewebstore\.google\.com\/.*/)) {
                         continue;
                     }
 

--- a/docs/help.css
+++ b/docs/help.css
@@ -48,6 +48,7 @@ table tr:nth-child(2n) {
 
 div#body-container {
     background-color: white;
+    color: black;
     max-width: 800px;
     margin: auto;
     padding: 10px;

--- a/docs/help.css
+++ b/docs/help.css
@@ -149,11 +149,11 @@ input[type='checkbox'] {
     border-left: 4px solid currentColor;
     vertical-align: middle;
     margin-right: .7rem;
-    transform: translateY(-2px);
+    transform: rotate(90deg) translateX(-3px);
 }
 
 .toggle:checked + .lbl-toggle::before {
-    transform: rotate(90deg) translateX(-3px);
+    transform: rotate(0deg) translateY(-3px);
 }
 
 .toggle:checked + .lbl-toggle + .collapsible-content {

--- a/docs/index.html
+++ b/docs/index.html
@@ -351,7 +351,7 @@ wrapperElement.setAttribute('id', identifierUUID);
 			<div class="content-inner">
 				<p>You can also use the omnibox to highlight occurrences of a query in the page, rather than opening the
 					browser extension popup.</p>
-				<p>To use this feature, type "find" in your browser's address bar, press space, and then enter a regular
+				<p>To use this feature, type "findplus" in your browser's address bar, press space, and then enter a regular
 					expression. Occurrences of the regular expression will become highlighted on the page as you
 					type.</p>
 				<p>Pressing <kbd>ENTER</kbd> will leave the highlights in the page. To remove the highlights, simply

--- a/docs/index.html
+++ b/docs/index.html
@@ -74,7 +74,7 @@
 						<div class="content-inner">
 							The following example matches any quoted date with the format "####-##-##".
 
-							<pre>"\d{4}-\d{2}-\d{d}"</pre>
+							<pre>"\d{4}-\d{2}-\d{2}"</pre>
 							<pre>
 {
     "Version": <span style="background-color: #ff9813">"2012-10-17"</span>,

--- a/manifest.json
+++ b/manifest.json
@@ -46,7 +46,7 @@
     ]
   }],
   "omnibox": {
-    "keyword" : "find"
+    "keyword" : "findplus"
   },
   "commands": {
     "_execute_browser_action": {

--- a/manifest_firefox.json
+++ b/manifest_firefox.json
@@ -44,7 +44,7 @@
     ]
   }],
   "omnibox": {
-    "keyword" : "find"
+    "keyword" : "findplus"
   },
   "commands": {
     "_execute_browser_action": {

--- a/popup/css/extension.css
+++ b/popup/css/extension.css
@@ -3,6 +3,7 @@
 body {
     margin: 3px;
     width: 410px;
+    background-color: white;
 }
 
 div.pane {

--- a/popup/css/searchpane.css
+++ b/popup/css/searchpane.css
@@ -32,7 +32,7 @@ div#search-info {
 }
 
 span#index-text {
-    color: #CCCCCC;
+    color: #888888;
     white-space: nowrap;
     text-align: right;
 }

--- a/popup/js/browser-action.js
+++ b/popup/js/browser-action.js
@@ -269,6 +269,7 @@ Find.register('Popup.BrowserAction', function (self) {
      * */
     function isWithinWebStoreNamespace(url) {
         return url.match(/https:\/\/chrome\.google\.com\/webstore\/.*/)
+            || url.match(/https:\/\/chromewebstore\.google\.com\/.*/)
             || url.match(/https:\/\/google\.[^\/]*\/_\/chrome\/newtab.*/);
     }
 

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -311,9 +311,9 @@
             </div>
             <div id="saved-expressions-body-controls">
                 <button class="text-btn warn def-font" id="clear-saved-expressions-button" type="button"
-                        data-locale-title="clear_expressions_button_title">Clear Saved Expressions</button>
+                        data-locale-title="clear_expressions_button_title"><span class="pane-header" data-locale-text="clear_expressions_button_text"></span></button>
                 <button class="text-btn def-font" id="save-expression-entry-button" type="button"
-                        data-locale-title="save_expression_button_title">Save Expression</button>
+                        data-locale-title="save_expression_button_title"><span class="pane-header" data-locale-text="save_expression_button_text"></span></button>
             </div>
         </div>
     </body>


### PR DESCRIPTION
The current situation that `find` is a keyword is too common.

`findplus` is at least less likely to clash with searches.

## Fixes #

### Changes Proposed in this Pull Request:
- Change keyword to findplus

### Additional Comments and Documentation:
