### PR TITLE
Check if the zip utility is installed before any actions

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -81,6 +81,12 @@ if [ -z "$VERSION" ]; then
     help
 fi
 
+# Check if zip is installed
+if [ zip ]; then
+    echo "Error: missing 'zip' utility."
+    exit 2
+fi
+
 # Create build directory structure
 echo "$ME: Creating the build directory structure under $BUILD_DIR..."
 rm -rf "$BUILD_DIR"

--- a/build.sh
+++ b/build.sh
@@ -82,7 +82,7 @@ if [ -z "$VERSION" ]; then
 fi
 
 # Check if zip is installed
-if [ zip ]; then
+if ! command -v zip >/dev/null; then
     echo "Error: missing 'zip' utility."
     exit 2
 fi


### PR DESCRIPTION
### Changes Proposed in this Pull Request:
- Check if the zip utility is installed before any actions

### Additional Comments and Documentation:

Before:

```console
$ zip
Command 'zip' not found, but can be installed with:
sudo apt install zip

$ ./build.sh -v '1.4.4'
./build.sh: Creating the build directory structure under .../find/.build...
mkdir: created directory '.../find/.build'
mkdir: created directory '.../find/.build/chr'
mkdir: created directory '.../find/.build/moz'
./build.sh: Copying project source files to build directory...
./build.sh: Updating version number in manifest to 1.4.4...
./build.sh: Packaging extension for Chrome...
./build.sh: line 109: zip: command not found
./build.sh: Packaging extension for Firefox...
./build.sh: line 116: zip: command not found

```

After:

```console
$ zip
Command 'zip' not found, but can be installed with:
sudo apt install zip

$ ./build.sh -v '1.4.4'
Error: missing 'zip' utility.

```

.