### PR TITLE
Drop the "tabs" permission

### DIFF
--- a/background/background.js
+++ b/background/background.js
@@ -43,7 +43,8 @@ Find.register("Background", function(self) {
             Find.browser.tabs.query({}, (tabs) => {
                 for(let tabIndex = 0; tabIndex < tabs.length; tabIndex++) {
                     let url = tabs[tabIndex].url;
-                    if(url.match(/chrome:\/\/.*/)
+                    // Without the "tabs" permission, browser's internal webpage (e.g., "chrome://" or "chrome-extension://") has no "url"
+                    if(!url
                         || url.match(/https:\/\/chrome\.google\.com\/webstore\/.*/)
                         || url.match(/https:\/\/chromewebstore\.google\.com\/.*/)) {
                         continue;

--- a/manifest.json
+++ b/manifest.json
@@ -10,7 +10,6 @@
   "description": "__MSG_extension_description__",
   "default_locale": "en",
   "permissions": [
-    "tabs",
     "activeTab",
     "background",
     "storage",

--- a/manifest_firefox.json
+++ b/manifest_firefox.json
@@ -7,7 +7,6 @@
   "description": "__MSG_extension_description__",
   "default_locale": "en",
   "permissions": [
-    "tabs",
     "activeTab",
     "storage",
     "contextMenus",


### PR DESCRIPTION
## Fixes #415

### Changes Proposed in this Pull Request:

- Drop the "tabs" permission.
- Slightly simplify a conditional statement.

### Additional Comments and Documentation:

Just an attempt to see if we can say goodbye to "Read your browsing history".

I've noticed that the `browser.tabs.query(...)` call produces URLs of "valid" tabs (e.g. "chrome://extensions/" is `undefined`, so it should be ignored). I don't exactly know what "active tabs" are because I've found multiple `{"active": false}` tab in `tabs`. 

I can highlight strings matching the pattern in both popup and omnibox after dropping that permission.

See also:

- The "activeTab" permission  |  Chrome Extensions  |  Chrome for Developers https://developer.chrome.com/docs/extensions/develop/concepts/activeTab
- tabs - Mozilla | MDN https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs
- Chrome extension tabs permissions shows "Read your browsing history" - Stack Overflow https://stackoverflow.com/q/64063754

> ```cpp
>         // "title" and "url" properties are considered privileged data and can
>         // only be checked if the extension has the "tabs" permission or it has
>         // access to the WebContents's origin. Otherwise, this tab is considered
>         // not matched.
> ```
> 
> from:
> - https://chromium.googlesource.com/chromium/src/+/refs/tags/120.0.6046.0/chrome/browser/extensions/api/tabs/tabs_api.cc#1266
> - https://github.com/chromium/chromium/blob/4d5ffc8d21ca9ec585593cb5e080da0e781ef0ae/chrome/browser/extensions/api/tabs/tabs_api.cc#L1266-L1269

.