### PR TITLE
Ignore URLs that belong to browser namespaces or official websites

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -141,13 +141,9 @@
     "message": "Replace All",
     "description": "Text displayed inside the replace all button."
   },
-  "extension_limitation_web_store_text": {
-    "message": "Oops! It appears you are trying to use the extension in the Chrome Web Store. Developers at Google have blocked extensions from executing here to prevent the malicious injection of code. This is a security limitation across all Chrome extensions.",
-    "description": "Text displayed in the message pane when the extension is used in the Chrome Web Store."
-  },
-  "extension_limitation_chrome_namespace_text": {
-    "message": "Oops! It appears you are trying to use the extension in the 'chrome://' namespace. Developers at Google have blocked extensions from executing here to prevent the malicious injection of code. This is a security limitation across all Chrome extensions.",
-    "description": "Text displayed in the message pane when the extension is used in the chrome:// namespace."
+  "extension_limitation_internal_restricted_browser_page_text": {
+    "message": "Oops! It appears you are trying to use the extension in a restricted internal browser page. Browser developers have blocked extensions from executing here to prevent the malicious injection of code. This is a security limitation across all browser extensions.",
+    "description": "Text displayed in the message pane when the extension is used in an internal restrcited browser page."
   },
   "extension_limitation_pdf_text": {
     "message": "Oops! It appears you are trying to use the extension in a PDF document. Unfortunately, due to the complexity of the PDF viewer our extension is not able to handle searching through a PDF. We recommend using the native tool instead.",

--- a/_locales/zh/messages.json
+++ b/_locales/zh/messages.json
@@ -141,13 +141,9 @@
     "message": "全部替换",
     "description": "Text displayed inside the replace all button."
   },
-  "extension_limitation_web_store_text": {
-    "message": "哎呀！您似乎正在 Chrome 应用商店中使用本扩展程序。Google 的开发者设置了安全限制，屏蔽了所有的 Chrome 扩展程序以避免恶意代码注入。",
-    "description": "Text displayed in the message pane when the extension is used in the Chrome Web Store."
-  },
-  "extension_limitation_chrome_namespace_text": {
-    "message": "哎呀！您似乎正在“chrome://”命名空间中使用本扩展程序。Google 的开发者设置了安全限制，屏蔽了所有的 Chrome 扩展程序以避免恶意代码注入。",
-    "description": "Text displayed in the message pane when the extension is used in the chrome:// namespace."
+  "extension_limitation_internal_restricted_browser_page_text": {
+    "message": "哎呀！您似乎正在浏览器内部页面或某些受限制的页面中使用本扩展程序。为避免遭受恶意代码的攻击，浏览器开发者对所有的扩展程序都施加了安全限制，因此本扩展程序无法在该页面运行。",
+    "description": "Text displayed in the message pane when the extension is used in an internal restrcited browser page."
   },
   "extension_limitation_pdf_text": {
     "message": "哎呀！您似乎正在 PDF 文档中使用本扩展程序。由于浏览器的内置阅读器比较复杂，很遗憾，我们无法进行查找，建议改用专门的 PDF 阅读器",

--- a/background/background.js
+++ b/background/background.js
@@ -45,8 +45,9 @@ Find.register("Background", function(self) {
                     let url = tabs[tabIndex].url;
                     // Without the "tabs" permission, browser's internal webpage (e.g., "chrome://" or "chrome-extension://") has no "url"
                     if(!url
-                        || url.match(/https:\/\/chrome\.google\.com\/webstore\/.*/)
-                        || url.match(/https:\/\/chromewebstore\.google\.com\/.*/)) {
+                        || url.match(/^https:\/\/chrome\.google\.com\/webstore\/.*/)
+                        || url.match(/^https:\/\/chromewebstore\.google\.com\/.*/)
+                        || url.match(/^https:\/\/microsoftedge\.microsoft\.com\/.*/)) {
                         continue;
                     }
 

--- a/popup/css/messagepane.css
+++ b/popup/css/messagepane.css
@@ -9,8 +9,7 @@ table#message-table {
     padding: 3px;
 }
 
-span#extension-limitation-web-store-text,
-span#extension-limitation-chrome-settings-text,
+span#extension-limitation-internal-restricted-browser-page-text,
 span#extension-limitation-pdf-fileview-text,
 span#extension-limitation-offline-file-search-text {
     color: #FF0000;

--- a/popup/js/browser-action.js
+++ b/popup/js/browser-action.js
@@ -57,11 +57,8 @@ Find.register('Popup.BrowserAction', function (self) {
         // this is the only time we have the active window hostname
         Find.Popup.History.setHostname(new URL(url).hostname);
 
-        if(isWithinChromeNamespace(url)) {
-            Find.Popup.MessagePane.showChromeNamespaceErrorMessage();
-            self.error('forbidden_url');
-        } else if(isWithinWebStoreNamespace(url)) {
-            Find.Popup.MessagePane.showChromeWebStoreErrorMessage();
+        if(isWithinBrowserNamespace(url) || isWithinBrowserWebsiteNamespace(url)) {
+            Find.Popup.MessagePane.showInternalRestrictedBrowserPageErrorMessage();
             self.error('forbidden_url');
         } else if(isPDF(url)) {
             Find.Popup.MessagePane.showPDFSearchErrorMessage();
@@ -252,25 +249,39 @@ Find.register('Popup.BrowserAction', function (self) {
     };
 
     /**
-     * Return whether or not the given url is within the chrome:// namespace.
+     * Return whether or not the given url is within the browser internal namespace.
      *
      * @private
-     * @return {boolean} True if URL is within the chrome:// namespace, false otherwise.
+     * @return {boolean} True if URL is within the browser internal namespace, false otherwise.
      * */
-    function isWithinChromeNamespace(url) {
-        return url.match(/chrome:\/\/.*/);
+    function isWithinBrowserNamespace(url) {
+        if(url.match(/^(about|view-source):.*/)) {
+            return true;
+        }
+
+        if(Find.browserId !== 'Firefox') {
+            return url.match(/^(chrome(-extension)?|edge):\/\/.*/);
+        } else {
+            return url.match(/^moz-extension:\/\/.*/);
+        }
     }
 
     /**
-     * Return whether or not the given url is within the Chrome Web Store or newtab namespace.
+     * Return whether or not the given url is within the browser official website or newtab namespace.
      *
      * @private
-     * @return {boolean} True if URL is within the Chrome Web Store or newtab namespace, false otherwise.
+     * @return {boolean} True if URL is within the browser official website or newtab namespace, false otherwise.
      * */
-    function isWithinWebStoreNamespace(url) {
-        return url.match(/https:\/\/chrome\.google\.com\/webstore\/.*/)
-            || url.match(/https:\/\/chromewebstore\.google\.com\/.*/)
-            || url.match(/https:\/\/google\.[^\/]*\/_\/chrome\/newtab.*/);
+    function isWithinBrowserWebsiteNamespace(url) {
+        if(Find.browserId !== 'Firefox') {
+            return url.match(/^https:\/\/chrome\.google\.com\/webstore\/.*/)
+                || url.match(/^https:\/\/chromewebstore\.google\.com\/.*/)
+                || url.match(/^https:\/\/microsoftedge\.microsoft\.com\/.*/)
+                || url.match(/^https:\/\/google\.[^\/]*\/_\/chrome\/newtab.*/);
+        } else {
+            return url.match(/^https:\/\/addons\.mozilla\.org\/.*/)
+                || url.match(/^https:\/\/support\.mozilla\.org\/.*/);
+        }
     }
 
     /**

--- a/popup/js/message-pane.js
+++ b/popup/js/message-pane.js
@@ -8,18 +8,10 @@ Find.register('Popup.MessagePane', function (self) {
     /**
      * Display an error message that indicates that the current URL is forbidden.
      * */
-    self.showChromeNamespaceErrorMessage = function() {
+    self.showInternalRestrictedBrowserPageErrorMessage = function() {
         document.getElementById('extension-message-body').style.display = 'initial';
-        document.getElementById('extension-limitation-chrome-settings-text').style.display = 'initial';
-    };
-
-    /**
-     * Display an error message that indicates that the current URL is forbidden.
-     * */
-    self.showChromeWebStoreErrorMessage = function() {
-        document.getElementById('extension-message-body').style.display = 'initial';
-        document.getElementById('extension-limitation-web-store-text').style.display = 'initial';
-    };
+        document.getElementById('extension-limitation-internal-restricted-browser-page-text').style.display = 'initial';
+    }
 
     /**
      * Display an error message that indicates that the current page cannot be parsed.

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -89,10 +89,8 @@
                         <img id="exclamation-icon" src="img/icon/exclamation.svg"/>
                     </td>
                     <td>
-                        <span class="def-font" id="extension-limitation-web-store-text"
-                              data-locale-text="extension_limitation_web_store_text"></span>
-                        <span class="def-font" id="extension-limitation-chrome-settings-text"
-                              data-locale-text="extension_limitation_chrome_namespace_text"></span>
+                        <span class="def-font" id="extension-limitation-internal-restricted-browser-page-text"
+                              data-locale-text="extension_limitation_internal_restricted_browser_page_text"></span>
                         <span class="def-font" id="extension-limitation-pdf-fileview-text"
                               data-locale-text="extension_limitation_pdf_text"></span>
                         <span class="def-font" id="extension-limitation-offline-file-search-text"


### PR DESCRIPTION
## Fixes nothing

### Changes Proposed in this Pull Request:
- Ignore more URLs that belong to browser internal namespaces or vendor official websites.
- Rename some varaibles and elements to represent the accurate meaning.
- I know Simplified Chinese, so update the l10n messages.

### Additional Comments and Documentation:

#### L10N

Please help me rephrase English sentences if they look awkward.

#### New Added Link Examples

- Internal namespaces:
    - `chrome-extension://...`: The "docs/index.html" page of this extension: `chrome-extension://fddffkdncgkkdjobemgbpojjeffmmofb/docs/index.html` . The UI of Microsoft Edge hides the "chrome-" prefix.
    - `edge://...`: `edge://about`
    - `moz-extension://...`: The "docs/index.html" page of this extension.
    - `about:...` (Firefox): `about:about`
- Official websites:
    - https://microsoftedge.microsoft.com/
    - https://addons.mozilla.org/
    - https://support.mozilla.org/

#### Chromium

I don't distinguish between Microsoft Edge and Google Chrome.

#### Firefox

The toolbar button (browser action) will say "`Can’t read and change data on this site`" if the current URL is unsupported:

https://github.com/mozilla/gecko-dev/blob/c3fd24fa4836680544dee8c31276bb9159a5308d/browser/locales/en-US/browser/originControls.ftl#L38

https://searchfox.org/mozilla-central/rev/c3fd24fa4836680544dee8c31276bb9159a5308d/browser/locales/en-US/browser/originControls.ftl#38

... but I haven't found any API about getting that state.
