### PR TITLE
Add Japanese (ja) localization

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -14,7 +14,7 @@
     "description": "Tooltip text for the search field."
   },
   "malformed_regex_error_title": {
-    "message": "Malformed Regex:\nThe regular expression entered is not acceptable, as it is either an invalid regular expression, or not supported according to the Javascript RegExp specification",
+    "message": "Malformed Regex:\nThe regular expression entered is not acceptable, as it is either an invalid regular expression, or not supported according to the JavaScript RegExp specification",
     "description": "Tooltip text for the invalid regex icon."
   },
   "clipboard_copy_error_title": {

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -1,0 +1,235 @@
+{
+  "extension_name": {
+    "message": "find+ | 正規表現ページ内検索ツール",
+    "description": "The extension name in the manifest file."
+  },
+  "extension_description": {
+    "message": "正規表現対応のページ内検索拡張機能",
+    "description": "Short description of the extension in the manifest file."
+  },
+
+
+  "search_field_title": {
+    "message": "検索フィールド",
+    "description": "Tooltip text for the search field."
+  },
+  "malformed_regex_error_title": {
+    "message": "無効な正規表現:\n入力された正規表現は無効か、JavaScriptのRegExpに非対応です",
+    "description": "Tooltip text for the invalid regex icon."
+  },
+  "clipboard_copy_error_title": {
+    "message": "予期しないエラーにより、クリップボードにコピーできませんでした",
+    "description": "Tooltip text for the clipboard copy error icon."
+  },
+  "iframes_found_warning_title": {
+    "message": "ページ内にiframeが含まれています。一部の検索結果がハイライトされない場合があります",
+    "description": "Tooltip text for the iframes encountered warning icon."
+  },
+  "clipboard_copy_title": {
+    "message": "一致箇所をクリップボードにコピーしました",
+    "description": "Tooltip text for the clipboard copy successful icon."
+  },
+  "installation_information_title": {
+    "message": "ご利用ありがとうございます！操作のヒント：\n\tENTER：次の一致箇所へ\n\tSHIFT-ENTER：前の一致箇所へ\n\tCTRL-ALT-O：オプション表示／非表示\n\tCTRL-ALT-R：置換パネル表示／非表示\n\tCTRL-ENTERまたはESC：拡張機能を閉じる",
+    "description": "Tooltip text for the install information icon."
+  },
+  "update_information_title": {
+    "message": "拡張機能を更新しました！\n詳細はGitHubページをご確認ください",
+    "description": "Tooltip text for the update information icon."
+  },
+  "search_prev_title": {
+    "message": "前へ",
+    "description": "Tooltip text for the seek backwards button."
+  },
+  "search_next_title": {
+    "message": "次へ",
+    "description": "Tooltip text for the seek forwards button."
+  },
+  "toggle_options_pane_title": {
+    "message": "オプション表示切替",
+    "description": "Tooltip text for the toggle options pane button."
+  },
+  "toggle_saved_expressions_button": {
+    "message": "保存済み式を表示",
+    "description": "Tooltip text for the show saved expressions button."
+  },
+  "copy_to_clipboard_button_title": {
+    "message": "すべての一致をコピー",
+    "description": "Tooltip text for the copy to clipboard button."
+  },
+  "toggle_find_replace_button_title": {
+    "message": "検索と置換",
+    "description": "Tooltip text for the find and replace toggle button."
+  },
+  "close_extension_title": {
+    "message": "find+を閉じる",
+    "description": "Tooltip text for the close extension button."
+  },
+  "replace_field_title": {
+    "message": "置換フィールド",
+    "description": "Tooltip text for the replace field."
+  },
+  "replace_button_title": {
+    "message": "次を置換",
+    "description": "Tooltip text for the replace next button."
+  },
+  "replace_all_button_title": {
+    "message": "すべて置換",
+    "description": "Tooltip text for the replace all button."
+  },
+  "search_option_find_by_regex_title": {
+    "message": "有効時：検索フィールドのテキストを正規表現として扱います\n無効時：通常のテキストとして扱います",
+    "description": "Tooltip text for the find by regex option description icon."
+  },
+  "search_option_match_case_title": {
+    "message": "有効時：大文字と小文字を区別します\n無効時：大文字と小文字を区別しません",
+    "description": "Tooltip text for the match case option description icon."
+  },
+  "search_option_persistent_highlights_title": {
+    "message": "有効時：拡張機能を閉じてもハイライトを維持します\nページ再読み込みまたは拡張機能を再度開くと解除されます",
+    "description": "Tooltip text for the persistent highlights option description icon."
+  },
+  "extension_option_persistent_storage_incognito_title": {
+    "message": "有効時：通常およびシークレットセッションで設定を保持します\n無効時：シークレット時は情報を保存しません",
+    "description": "Tooltip text for the persistent storage incognito option description icon."
+  },
+  "extension_option_hide_option_pane_toggle_button_title": {
+    "message": "有効時：オプションパネルの切替ボタンを非表示にします\nキーボードショートカットは引き続き使用できます",
+    "description": "Tooltip text for the hide option pane toggle button option description icon."
+  },
+  "extension_option_hide_saved_expressions_pane_toggle_button_title": {
+    "message": "有効時：保存済み式パネルの切替ボタンを非表示にします\nキーボードショートカットは引き続き使用できます",
+    "description": "Tooltip text for the hide saved expressions pane toggle button option description icon."
+  },
+  "extension_option_hide_copy_to_clipboard_toggle_button_title": {
+    "message": "有効時：クリップボードへのコピーボタンを非表示にします\nキーボードショートカットは引き続き使用できます",
+    "description": "Tooltip text for the copy all occurrences to clipboard button option description icon."
+  },
+  "extension_option_hide_find_replace_toggle_button_title": {
+    "message": "有効時：検索と置換パネルの切替ボタンを非表示にします\nキーボードショートカットは引き続き使用できます",
+    "description": "Tooltip text for the hide find and replace pane toggle button option description icon."
+  },
+  "saved_expression_icon_title": {
+    "message": "この式を読み込む",
+    "description": "Tooltip text for a saved expression entry icon."
+  },
+  "delete_saved_expression_icon_title": {
+    "message": "この式を削除",
+    "description": "Tooltip text for a delete saved expression entry icon."
+  },
+  "clear_expressions_button_title": {
+    "message": "保存済み式をすべて削除",
+    "description": "Tooltip text for the clear saved expressions button."
+  },
+  "save_expression_button_title": {
+    "message": "検索フィールドの式を保存",
+    "description": "Tooltip text for the save expression button."
+  },
+
+
+  "replace_field_placeholder": {
+    "message": "置換後のテキスト",
+    "description": "Placeholder text for the replace field."
+  },
+
+
+  "replace_button_text": {
+    "message": "置換",
+    "description": "Text displayed inside the replace button."
+  },
+  "replace_all_button_text": {
+    "message": "すべて置換",
+    "description": "Text displayed inside the replace all button."
+  },
+  "extension_limitation_internal_restricted_browser_page_text": {
+    "message": "このページでは拡張機能を使用できません。ブラウザの内部ページでの実行はセキュリティ上の理由でブロックされています",
+    "description": "Text displayed in the message pane when the extension is used in an internal restrcited browser page."
+  },
+  "extension_limitation_pdf_text": {
+    "message": "PDFドキュメントには対応していません。ブラウザ標準の検索機能をご利用ください",
+    "description": "Text displayed in the message pane when the extension is used in a PDF."
+  },
+  "extension_limitation_offline_file_text": {
+    "message": "オフラインファイルの検索中にエラーが発生しました。'chrome://extensions'から{find+}の「ファイルのURLへのアクセスを許可する」を有効にしてください",
+    "description": "Text displayed in the message pane when the extension is used in an offline file without adequate permissions for parsing file contents."
+  },
+  "search_options_header_text": {
+    "message": "検索オプション",
+    "description": "Header text displayed in the options pane."
+  },
+  "extension_options_header_text": {
+    "message": "拡張機能オプション",
+    "description": "Header text displayed in the options pane."
+  },
+  "saved_expressions_body_header": {
+    "message": "保存済み式",
+    "description": "Header text displayed in the saved expressions pane."
+  },
+  "search_option_find_by_regex_text": {
+    "message": "正規表現で検索",
+    "description": "Text displayed beside the find by regex option."
+  },
+  "search_option_match_case_text": {
+    "message": "大文字と小文字を区別",
+    "description": "Text displayed beside the match case option."
+  },
+  "search_option_persistent_highlights_text": {
+    "message": "ハイライトを維持",
+    "description": "Text displayed beside the persistent highlights option."
+  },
+  "extension_option_persistent_storage_incognito_text": {
+    "message": "設定を保持（シークレット）",
+    "description": "Text displayed beside the persistent storage option."
+  },
+  "extension_option_hide_option_pane_toggle_button_text": {
+    "message": "オプションボタンを非表示",
+    "description": "Text displayed beside the hide option pane toggle button option."
+  },
+  "extension_option_hide_saved_expressions_pane_toggle_button_text": {
+    "message": "保存済み式ボタンを非表示",
+    "description": "Text displayed beside the hide saved expressions pane toggle button option."
+  },
+  "extension_option_hide_copy_to_clipboard_toggle_button_text": {
+    "message": "コピーボタンを非表示",
+    "description": "Text displayed beside the hide copy to clipboard toggle button option."
+  },
+  "extension_option_hide_find_replace_toggle_button_text": {
+    "message": "検索と置換ボタンを非表示",
+    "description": "Text displayed beside the hide find and replace toggle button option."
+  },
+  "search_option_max_results_text": {
+    "message": "最大ハイライト数",
+    "description": "Text displayed above the max highlighted results option."
+  },
+  "search_option_index_highlight_text": {
+    "message": "選択中のハイライト色",
+    "description": "Text displayed above the index highlight color option."
+  },
+  "search_option_all_highlight_text": {
+    "message": "ハイライト色",
+    "description": "Text displayed above the all highlight color option."
+  },
+  "reset_options_button_text": {
+    "message": "すべてリセット",
+    "description": "Text displayed in the reset options button."
+  },
+
+  "no_expressions_found_text": {
+    "message": "保存済み式はありません",
+    "description": "Text displayed in the saved expressions pane when no expressions exist."
+  },
+  "clear_expressions_button_text":{
+    "message": "保存済み式を削除",
+    "description": "Text displayed in the saved expressions pane."
+  },
+  "save_expression_button_text":{
+    "message": "式を保存",
+    "description": "Text displayed in the saved expressions pane."
+  },
+
+
+  "contextmenu_show_help_title": {
+    "message": "ヘルプを表示",
+    "description": "Text displayed inside the show-help button in the context menu."
+  }
+}


### PR DESCRIPTION
## Fixes #
N/A

### Changes Proposed in this Pull Request:
- Added Japanese (ja) localization (`_locales/ja/messages.json`)
- Translated all 56 messages with simple and concise style
- Verified no UI layout issues

### Additional Comments and Documentation:
- Tested locally with Chrome (unpacked extension)
- Screenshots attached below
![01jp](https://github.com/user-attachments/assets/4d78b184-ba47-4bc4-93bb-846a2893f3d8)
![02jp](https://github.com/user-attachments/assets/98e76b08-d828-454f-b723-682c285148b3)
